### PR TITLE
remove node version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.0.10",
+  "version": "0.0.8",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",
@@ -22,9 +22,6 @@
     "clean": "rimraf lib dist es coverage",
     "prepublish": "yarn clean && yarn build",
     "storybook": "start-storybook -p 6006"
-  },
-  "engines": {
-    "node": "12.10"
   },
   "keywords": [
     "netdata",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.0.8",
+  "version": "0.0.11",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,10 +1636,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@netdata/netdata-ui@^1.6.7":
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/@netdata/netdata-ui/-/netdata-ui-1.6.7.tgz#2c81690ac260e2688a299c55e49943d9a3cbe4f3"
-  integrity sha512-mCZyhWQvMz0QwkDGCF5MlmThcqUP4iBjwnDbms0oW/kbiMVvLTHm89Q46u25f4Vuz/+tFDTdy4ZwKeXS0Mt6nQ==
+"@netdata/netdata-ui@^1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@netdata/netdata-ui/-/netdata-ui-1.6.9.tgz#c44dabc754141cd06f4a751aee1f492d13c863b1"
+  integrity sha512-VNTxqY4HSqyfD0yAd0A2I2ED/+3TQ1JMvA3Hjb9vZ4M1b0yT3k0Gwgi/sat7AhtajR4laDbQ795p435FOHESQA==
   dependencies:
     "@elastic/react-search-ui" "^1.5.1"
     "@elastic/search-ui-site-search-connector" "^1.5.1"


### PR DESCRIPTION
Can we remove engine requirement?
I'm using node@16, and Apple's M1 is supported only from node@15. I'm overriding the engine/node version locally in cloud-fe but it will be harder to override an npm package this way.