### PR TITLE
Added early return for empty data.

### DIFF
--- a/src/chartLibraries/easyPie/index.js
+++ b/src/chartLibraries/easyPie/index.js
@@ -108,7 +108,10 @@ export default (sdk, chart) => {
     const { result } = chart.getPayload()
     const row = hoverX ? chart.getClosestRow(hoverX[0]) : result.data.length - 1
 
-    const [, ...rows] = result.data[row]
+    const rowData = result.data[row]
+    if (!Array.isArray(rowData)) return
+
+    const [, ...rows] = rowData
     const value = rows.reduce((acc, v) => acc + v, 0)
     let [min, max] = getMinMax(value)
 

--- a/src/chartLibraries/gauge/index.js
+++ b/src/chartLibraries/gauge/index.js
@@ -100,7 +100,11 @@ export default (sdk, chart) => {
 
     const row = hoverX ? chart.getClosestRow(hoverX[0]) : result.data.length - 1
 
-    const [, ...rows] = result.data[row]
+    const rowData = result.data[row]
+    if (!Array.isArray(rowData)) return
+
+    const [, ...rows] = rowData
+
     const value = rows.reduce((acc, v) => acc + v, 0)
 
     let [min, max] = getMinMax(value)


### PR DESCRIPTION
Do we have other cases with `result.data` computations to catch when empty?