### PR TITLE
fix: hide NaN in latest value overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/src/components/line/overlays/latestValue.js
+++ b/src/components/line/overlays/latestValue.js
@@ -8,7 +8,7 @@ const LatestValue = ({ dimensionId, ...rest }) => {
 
   return (
     <Text strong whiteSpace="nowrap" {...rest}>
-      {!value || isNaN(value) ? "No data" : `${value} ${unit}`}
+      {!value ? "No data" : `${value} ${unit}`}
     </Text>
   )
 }

--- a/src/components/line/overlays/latestValue.js
+++ b/src/components/line/overlays/latestValue.js
@@ -8,7 +8,7 @@ const LatestValue = ({ dimensionId, ...rest }) => {
 
   return (
     <Text strong whiteSpace="nowrap" {...rest}>
-      {!value ? "No data" : `${value} ${unit}`}
+      {!value || isNaN(value) ? "No data" : `${value} ${unit}`}
     </Text>
   )
 }

--- a/src/components/provider/selectors.js
+++ b/src/components/provider/selectors.js
@@ -183,6 +183,9 @@ export const useLatestValue = id => {
     index = index === -1 ? result.data.length - 1 : index
 
     const value = chart.getDimensionValue(id, index)
+
+    if (isNaN(value)) return null
+
     return chart.getConvertedValue(value)
   }
 


### PR DESCRIPTION
Update `latestValue` component to display the "No data" message when the received value is `null`

https://user-images.githubusercontent.com/38426486/145025380-bb2d3bfa-dbe3-40e0-b2b8-b717081838fe.mov
