### PR TITLE
charts/use-same-conversion-on-chart-legend-and-pill-when-highlighting

### DIFF
--- a/src/components/line/indicators/dateTime.js
+++ b/src/components/line/indicators/dateTime.js
@@ -32,7 +32,7 @@ const minute1 = 60
 
 const padZero = v => (v > 9 ? v : `0${v}`)
 
-const getDateDiff = (after, before) => {
+export const getDateDiff = (after, before) => {
   const initialDiff = (diff = before - after)
 
   const days = Math.floor(initialDiff / day1)

--- a/src/components/line/overlays/highlight/correlation.js
+++ b/src/components/line/overlays/highlight/correlation.js
@@ -5,6 +5,7 @@ import Icon, { Button } from "@/components/icon"
 import Tooltip from "@/components/tooltip"
 import { useChart, useAttributeValue } from "@/components/provider"
 import Badge from "@/components/line/badge"
+import { getDateDiff } from "@/components/line/indicators/dateTime"
 
 const minTimeframe = 15
 
@@ -18,9 +19,9 @@ export const Period = ({ id }) => {
   const { range } = overlays[id]
 
   const [after, before] = range
-  const total = before - after
+  const dateDiff = getDateDiff(after, before)
 
-  return <Badge type="neutral">{total}sec</Badge>
+  return <Badge type="neutral">{dateDiff}</Badge>
 }
 
 const Correlation = ({ id }) => {


### PR DESCRIPTION
Use the function `getDateDiff`, that is already being used on the legend, on the pill for consistency