### PR TITLE
 bug/composite-charts-show-no-data-on-group-by-change-if-dimension-selected

### DIFF
--- a/src/sdk/filters/makeControllers.js
+++ b/src/sdk/filters/makeControllers.js
@@ -23,6 +23,7 @@ export default chart => {
     }
     const attributes = getInitialFilterAttributes(chart)
     chart.updateAttributes(attributes)
+    chart.updateAttribute("selectedDimensions", null)
     chart.fetchAndRender()
   }
 


### PR DESCRIPTION
When we have a `dimension` highlighted in the chart's legend and then we change the `group by` method, we should set the highlight dimensions to the default value