### PR TITLE
feat/charts-tooltip-should-state-the-units-of-the-charts

### DIFF
--- a/src/components/line/dimensions/units.js
+++ b/src/components/line/dimensions/units.js
@@ -1,0 +1,22 @@
+import React, { memo } from "react"
+import { TextMicro } from "@netdata/netdata-ui/lib/components/typography"
+import { useUnitSign } from "@/components/provider"
+
+const Value = props => (
+  <TextMicro
+    color="textDescription"
+    whiteSpace="nowrap"
+    truncate
+    data-testid="chartDimensions-units"
+    {...props}
+  />
+)
+
+const Units = ({ visible }) => {
+  const units = useUnitSign()
+
+  if (!visible) return null
+  return <Value>{units}</Value>
+}
+
+export default memo(Units)

--- a/src/components/line/legend/dimension.js
+++ b/src/components/line/legend/dimension.js
@@ -2,11 +2,11 @@ import React from "react"
 import { useTheme } from "styled-components"
 import Flex from "@netdata/netdata-ui/lib/components/templates/flex"
 import { getColor } from "@netdata/netdata-ui/lib/theme/utils"
-import { TextMicro } from "@netdata/netdata-ui/lib/components/typography"
 import Color, { Color as ColorContainer } from "@/components/line/dimensions/color"
 import Name, { Name as NameContainer } from "@/components/line/dimensions/name"
 import Value, { Value as ValueContainer } from "@/components/line/dimensions/value"
-import { useUnitSign, useVisibleDimensionId, useChart } from "@/components/provider"
+import Units from "@/components/line/dimensions/units"
+import { useVisibleDimensionId, useChart } from "@/components/provider"
 
 const DimensionContainer = props => (
   <Flex width="88px" flex={false} gap={1} data-testid="chartLegendDimension" {...props} />
@@ -47,7 +47,6 @@ export const EmptyDimension = () => {
 }
 
 const Dimension = ({ id }) => {
-  const unit = useUnitSign()
   const visible = useVisibleDimensionId(id)
   const chart = useChart()
 
@@ -69,11 +68,7 @@ const Dimension = ({ id }) => {
 
         <Flex gap={1} data-testid="chartLegendDimension-valueContainer">
           <Value id={id} strong visible={visible} />
-          {visible && (
-            <TextMicro whiteSpace="nowrap" truncate color="textDescription">
-              {unit}
-            </TextMicro>
-          )}
+          <Units visible={visible} />
         </Flex>
       </Flex>
     </DimensionContainer>

--- a/src/components/line/popover/dimension.js
+++ b/src/components/line/popover/dimension.js
@@ -3,6 +3,7 @@ import Flex from "@netdata/netdata-ui/lib/components/templates/flex"
 import Color from "@/components/line/dimensions/color"
 import Name from "@/components/line/dimensions/name"
 import Value from "@/components/line/dimensions/value"
+import Units from "@/components/line/dimensions/units"
 import { useVisibleDimensionId } from "@/components/provider"
 
 const Dimension = ({ id, strong }) => {
@@ -18,6 +19,7 @@ const Dimension = ({ id, strong }) => {
       <Color id={id} height="12px" />
       <Flex as={Name} flex id={id} strong={strong} maxLength={80} />
       <Value id={id} strong={strong} visible={visible} />
+      <Units visible={visible} />
     </Flex>
   )
 }


### PR DESCRIPTION
- Make reusable `Units` component
- Use this component on chart's legend and tooltip

Resolves https://github.com/netdata/cloud-frontend/issues/2994