### PR TITLE
Adding 'abs' into agent_options, on data request payload

### DIFF
--- a/src/sdk/api/helpers.js
+++ b/src/sdk/api/helpers.js
@@ -1,5 +1,7 @@
 export const getChartURLOptions = chart => {
-  const { chartUrlOptions, urlOptions, eliminateZeroDimensions } = chart.getAttributes()
+  const { chartUrlOptions, composite, eliminateZeroDimensions, groupBy, urlOptions } =
+    chart.getAttributes()
+  const isSumOfAbs = composite && groupBy !== "dimension"
 
   return [
     ...(chartUrlOptions || chart.getUI().getUrlOptions()),
@@ -8,6 +10,7 @@ export const getChartURLOptions = chart => {
     eliminateZeroDimensions && "nonzero",
     "flip",
     "ms",
+    isSumOfAbs && "abs",
   ].filter(Boolean)
 }
 


### PR DESCRIPTION
Adding 'abs' into agent_options, when `Sum of ABS ` is applied on a composite chart, on `data` request payload