### PR TITLE
fix: update @netdata/dygraphs

### DIFF
--- a/jest/config.js
+++ b/jest/config.js
@@ -7,7 +7,7 @@ module.exports = {
   setupFiles: ["<rootDir>/jest/setup.js"],
   setupFilesAfterEnv: ["<rootDir>/jest/setupForEach.js"],
   verbose: true,
-  transformIgnorePatterns: ["node_modules/(?!(dygraphs)/*)"],
+  transformIgnorePatterns: ["node_modules/(?!(.?netdata|dygraphs)/*)"],
   moduleDirectories: ["node_modules", "src", "jest"],
   roots: ["src/"],
   collectCoverage: true,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "webpack-plugin": "^1.0.5"
   },
   "dependencies": {
-    "@netdata/dygraphs": "^2.1.0",
+    "@netdata/dygraphs": "^2.1.1",
     "d3-scale": "^4.0.2",
     "easy-pie-chart": "^2.1.7",
     "gaugeJS": "^1.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,10 +2812,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@netdata/dygraphs@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@netdata/dygraphs/-/dygraphs-2.1.0.tgz#7042f980fe6447b1ef6a3a33dabee1f7f07892bc"
-  integrity sha512-puVAiiGmTye8YcS4ECqc9yfN/xyxffB0GHNsa3mK5PKGPB2sQ1kSmuHFOqMByiNSIi4uIBNZ5UjXYxyBWRTFug==
+"@netdata/dygraphs@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@netdata/dygraphs/-/dygraphs-2.1.1.tgz#47c36a1580999752523dfe647a268c3a0334d66c"
+  integrity sha512-iZOmwvoNfjNvLcnbvnzCuIWjSsHrNR4+915T2WbXTHw7QgB7dk5+dPU/X4ufaIfSSx/ycqnJXj5lJIaBjT5zxg==
 
 "@netdata/netdata-ui@^1.7.49":
   version "1.7.49"


### PR DESCRIPTION

This PR resolves issue [#3106](https://github.com/netdata/cloud-frontend/issues/3106)

#### Solution
Update `@netdata/dygraphs` package, which includes the missing `src-es5` folder