### PR TITLE
chore: update dropdowns of charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.4.4-dev.0",
+  "version": "0.4.4-dev.1",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.0",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.4.4-dev.1",
+  "version": "0.4.4",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/src/components/line/filterToolbox/aggregate.js
+++ b/src/components/line/filterToolbox/aggregate.js
@@ -46,7 +46,7 @@ const Aggregate = ({ labelProps, ...rest }) => {
       {...rest}
     >
       <Label
-        secondaryLabel="Select"
+        secondaryLabel="the"
         label={short}
         title={tooltipAttrs.heading}
         tooltipProps={tooltipAttrs}

--- a/src/components/line/filterToolbox/dimensions.js
+++ b/src/components/line/filterToolbox/dimensions.js
@@ -76,7 +76,7 @@ const Dimensions = ({ labelProps, ...rest }) => {
       {...rest}
     >
       <Label
-        secondaryLabel="of"
+        secondaryLabel="select"
         label={label}
         title={tooltipProps.heading}
         tooltipProps={tooltipProps}

--- a/src/components/line/filterToolbox/dimensionsAggregation.js
+++ b/src/components/line/filterToolbox/dimensionsAggregation.js
@@ -25,8 +25,8 @@ const DimensionsAggregation = ({ isAggregate, labelProps }) => {
 
   return (
     <Label
-      secondaryLabel={isAggregate ? "of the" : ""}
-      label="Sum of ABS"
+      secondaryLabel={""}
+      label="sum of ABS"
       chevron={false}
       title={!!tooltipAttrs}
       tooltipProps={tooltipAttrs}

--- a/src/components/line/filterToolbox/label.js
+++ b/src/components/line/filterToolbox/label.js
@@ -27,12 +27,17 @@ const StyledLabel = styled(TextSmall).attrs({
   flex: 1;
 `
 
-const Label = forwardRef(({ secondaryLabel, label, chevron = true, ...rest }, ref) => (
+const Label = forwardRef(({ secondaryLabel, tertiaryLabel, label, chevron = true, ...rest }, ref) => (
   <Container ref={ref} {...rest}>
     <TextSmall color="textLite" whiteSpace="nowrap" truncate>
       {secondaryLabel}
     </TextSmall>
     <StyledLabel>{label}</StyledLabel>
+    {tertiaryLabel && (
+      <TextSmall color="textLite" whiteSpace="nowrap" truncate>
+        {tertiaryLabel}
+      </TextSmall>
+    )}
     {chevron && <Icon svg={chevronDown} size="16px" color="selected" />}
   </Container>
 ))

--- a/src/components/line/filterToolbox/label.js
+++ b/src/components/line/filterToolbox/label.js
@@ -29,9 +29,11 @@ const StyledLabel = styled(TextSmall).attrs({
 
 const Label = forwardRef(({ secondaryLabel, tertiaryLabel, label, chevron = true, ...rest }, ref) => (
   <Container ref={ref} {...rest}>
-    <TextSmall color="textLite" whiteSpace="nowrap" truncate>
-      {secondaryLabel}
-    </TextSmall>
+    {secondaryLabel && (
+      <TextSmall color="textLite" whiteSpace="nowrap" truncate>
+        {secondaryLabel}
+      </TextSmall>
+    )}
     <StyledLabel>{label}</StyledLabel>
     {tertiaryLabel && (
       <TextSmall color="textLite" whiteSpace="nowrap" truncate>

--- a/src/components/line/filterToolbox/timeAggregation.js
+++ b/src/components/line/filterToolbox/timeAggregation.js
@@ -1,0 +1,60 @@
+import React, { memo, useMemo } from "react"
+import Menu from "@netdata/netdata-ui/lib/components/drops/menu"
+import { useAttributeValue, useChart } from "@/components/provider"
+import Label from "./label"
+
+const useItems = chart =>
+  useMemo(
+    () => [
+      { value: "min", label: "Min", short: "MIN()", "data-track": chart.track("time-aggregation-min") },
+      { value: "max", label: "Max", short: "MAX()", "data-track": chart.track("time-aggregation-max") },
+      { value: "average", label: "Average", short: "AVG()", "data-track": chart.track("time-aggregation-average") },
+      { value: "sum", label: "Sum", short: "SUM()", "data-track": chart.track("time-aggregation-sum") },
+      { value: "incremental_sum", label: "Incremental sum (Delta)", short: "DELTA()", "data-track": chart.track("time-aggregation-incremental-sum") },
+      { value: "stddev", label: "Standard deviation", short: "STDDEV()", "data-track": chart.track("time-aggregation-stddev") },
+      { value: "median", label: "Median", short: "MEDIAN()", "data-track": chart.track("time-aggregation-median") },
+      { value: "ses", label: "Single exponential smoothing", short: "SES()", "data-track": chart.track("time-aggregation-ses") },
+      { value: "des", label: "Double exponential smoothing", short: "DES()", "data-track": chart.track("time-aggregation-des") },
+      { value: "cv", label: "Coefficient variation", short: "CV()", "data-track": chart.track("time-aggregation-cv") },
+    ],
+    [chart]
+  )
+
+const tooltipProps = {
+  dimension: {
+    heading: "Aggregation function over time",
+    body: "The aggregation function over time, for each of the metrics contributing to this query",
+  },
+}
+
+const TimeAggregation = ({ labelProps, ...rest }) => {
+  const chart = useChart()
+  const value = useAttributeValue("groupingMethod")
+  const { updateEvery = 0 } = chart.getMetadata()
+
+  const items = useItems(chart)
+
+  const { short } = items.find(item => item.value === value) || items[0]
+
+  return (
+    <Menu
+      value={value}
+      onChange={chart.updateTimeAggregationMethodAttribute}
+      items={items}
+      data-track={chart.track("groupingMethod")}
+      dropProps={{ align: { top: "bottom", right: "right" }, "data-toolbox": true }}
+      {...rest}
+    >
+      <Label
+        secondaryLabel="each as"
+        tertiaryLabel={`every ${updateEvery}s`}
+        label={short}
+        title={tooltipProps.heading}
+        tooltipProps={tooltipProps}
+        {...labelProps}
+      />
+    </Menu>
+  )
+}
+
+export default memo(TimeAggregation)

--- a/src/components/line/filterToolbox/timeAggregation.js
+++ b/src/components/line/filterToolbox/timeAggregation.js
@@ -10,7 +10,7 @@ const useItems = chart =>
       { value: "max", label: "Max", short: "MAX()", "data-track": chart.track("time-aggregation-max") },
       { value: "average", label: "Average", short: "AVG()", "data-track": chart.track("time-aggregation-average") },
       { value: "sum", label: "Sum", short: "SUM()", "data-track": chart.track("time-aggregation-sum") },
-      { value: "incremental_sum", label: "Incremental sum (Delta)", short: "DELTA()", "data-track": chart.track("time-aggregation-incremental-sum") },
+      { value: "incremental-sum", label: "Incremental sum (Delta)", short: "DELTA()", "data-track": chart.track("time-aggregation-incremental-sum") },
       { value: "stddev", label: "Standard deviation", short: "STDDEV()", "data-track": chart.track("time-aggregation-stddev") },
       { value: "median", label: "Median", short: "MEDIAN()", "data-track": chart.track("time-aggregation-median") },
       { value: "ses", label: "Single exponential smoothing", short: "SES()", "data-track": chart.track("time-aggregation-ses") },

--- a/src/components/line/filterToolbox/timeAggregation.js
+++ b/src/components/line/filterToolbox/timeAggregation.js
@@ -3,7 +3,7 @@ import Menu from "@netdata/netdata-ui/lib/components/drops/menu"
 import { useAttributeValue, useChart } from "@/components/provider"
 import Label from "./label"
 
-const useItems = chart =>
+const useMenuItems = chart =>
   useMemo(
     () => [
       { value: "min", label: "Min", short: "MIN()", "data-track": chart.track("time-aggregation-min") },
@@ -30,7 +30,7 @@ const TimeAggregation = ({ labelProps, ...rest }) => {
   const value = useAttributeValue("groupingMethod")
   const { updateEvery = 0 } = chart.getMetadata()
 
-  const items = useItems(chart)
+  const items = useMenuItems(chart)
 
   const { short } = items.find(item => item.value === value) || items[0]
 

--- a/src/components/line/filterToolbox/timeAggregation.js
+++ b/src/components/line/filterToolbox/timeAggregation.js
@@ -21,10 +21,8 @@ const useItems = chart =>
   )
 
 const tooltipProps = {
-  dimension: {
-    heading: "Aggregation function over time",
-    body: "The aggregation function over time, for each of the metrics contributing to this query",
-  },
+  heading: "Aggregation function over time",
+  body: "The aggregation function over time, for each of the metrics contributing to this query",
 }
 
 const TimeAggregation = ({ labelProps, ...rest }) => {

--- a/src/components/line/filterToolbox/useFiltersToolbox.js
+++ b/src/components/line/filterToolbox/useFiltersToolbox.js
@@ -49,7 +49,14 @@ export default () => {
     [chart]
   )
 
-  const aggregate = groupBy === "dimension" || (totalInstances > 0 && totalInstances > totalNodes)
+  const getAggregate = () => {
+    if (groupBy === "dimension") return true
+    if (groupBy === "chart") return false
+    if (totalInstances === 1) return false
+    return totalInstances > 0 && totalInstances > totalNodes;
+  }
+
+  const aggregate = getAggregate()
   const dimensionAggregation = groupBy !== "dimension" && hasDimensions
 
   return {

--- a/src/components/line/filterToolbox/useFiltersToolbox.js
+++ b/src/components/line/filterToolbox/useFiltersToolbox.js
@@ -50,9 +50,9 @@ export default () => {
   )
 
   const getAggregate = () => {
-    if (groupBy === "dimension") return true
     if (groupBy === "chart") return false
     if (totalInstances === 1) return false
+    if (groupBy === "dimension") return true
     return totalInstances > 0 && totalInstances > totalNodes;
   }
 

--- a/src/sdk/filters/getInitialAttributes.js
+++ b/src/sdk/filters/getInitialAttributes.js
@@ -21,6 +21,8 @@ export default chart => {
   const chartType = chart.getAttribute("chartType")
   const aggregationMethod = aggregationMethodAttr || getAggregateMethod(units)
 
+  // @todo re-visit the logic of the initial attributes
+  // It should keep pristine
   return {
     aggregationMethod,
     dimensions: dimensions?.length ? dimensions : getDimensions(chart, groupBy),

--- a/src/sdk/filters/makeControllers.js
+++ b/src/sdk/filters/makeControllers.js
@@ -78,6 +78,11 @@ export default chart => {
     chart.fetchAndRender()
   }
 
+  const updateTimeAggregationMethodAttribute = value => {
+    chart.updateAttribute("groupingMethod", value)
+    chart.fetchAndRender()
+  }
+
   const resetPristineComposite = () => {
     const attributes = chart.getAttributes()
     const prev = { ...attributes[pristineCompositeKey] }
@@ -107,6 +112,7 @@ export default chart => {
     updateGroupByAttribute,
     updateDimensionsAttribute,
     updateAggregationMethodAttribute,
+    updateTimeAggregationMethodAttribute,
     resetPristineComposite,
     removePristineComposite,
   }

--- a/src/sdk/pristineComposite.js
+++ b/src/sdk/pristineComposite.js
@@ -7,6 +7,7 @@ const { updatePristine, resetPristine } = makePristine(pristineCompositeKey, [
   "dimensions",
   "dimensionsAggregationMethod",
   "groupBy",
+  "groupingMethod",
   "chartType",
 ])
 


### PR DESCRIPTION
This PR resolves part of issue [Netdata Cloud #432](https://github.com/netdata/netdata-cloud/issues/432) and is a dependency to PR [Cloud Frontend #3523](https://github.com/netdata/cloud-frontend/pull/3523)

#### Solution
* Update labels of chart filters shown on **Room Overview** page of the app, so that they would be more descriptive and align better with the re-ordering of the filters
* Add a new filter for time aggregation
* Update logic for calculating value of `aggregate` constant

https://user-images.githubusercontent.com/38426486/172775104-cfd22cb6-f6cf-4d05-a47f-725ced09f883.mov
