### PR TITLE
wheel-scrolling updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/src/chartLibraries/dygraph/index.js
+++ b/src/chartLibraries/dygraph/index.js
@@ -94,7 +94,7 @@ export default (sdk, chart) => {
         touchmove: executeLatest.add((...args) => chartUI.trigger("touchmove", ...args)),
         touchend: executeLatest.add((...args) => chartUI.trigger("touchend", ...args)),
         dblclick: executeLatest.add((...args) => chartUI.trigger("dblclick", ...args)),
-        wheel: executeLatest.add((...args) => chartUI.trigger("wheel", ...args)),
+        wheel: (...args) => chartUI.trigger("wheel", ...args),
       },
 
       strokeBorderWidth: 0,

--- a/src/chartLibraries/dygraph/navigation/generic.js
+++ b/src/chartLibraries/dygraph/navigation/generic.js
@@ -53,6 +53,7 @@ export default chartUI => {
       const after = Math.round((afterAxis + afterIncrement) / 1000)
       const before = Math.round((beforeAxis - beforeIncrement) / 1000)
 
+      chartUI.chart.getUI().render()
       chartUI.chart.moveX(after, before)
     }
 

--- a/src/chartLibraries/dygraph/navigation/generic.js
+++ b/src/chartLibraries/dygraph/navigation/generic.js
@@ -30,6 +30,11 @@ export default chartUI => {
     })
   }
 
+  const getTime = seconds => {
+    if (seconds > 0) return seconds * 1000
+    return Date.now() + seconds * 1000
+  }
+
   const onZoom = (event, dygraph) => {
     if (!event.shiftKey && !event.altKey) return
 
@@ -38,7 +43,9 @@ export default chartUI => {
 
     const zoom = (g, zoomInPercentage, bias) => {
       bias = bias || 0.5
-      const [afterAxis, beforeAxis] = g.xAxisRange()
+      const attributes = chartUI.chart.getAttributes()
+      const afterAxis = getTime(attributes.after)
+      const beforeAxis = getTime(attributes.before)
       const delta = afterAxis - beforeAxis
       const increment = delta * zoomInPercentage
       const [afterIncrement, beforeIncrement] = [increment * bias, increment * (1 - bias)]


### PR DESCRIPTION
- fix stopPropagation(), by handling even synchronously, instead of setTimeout
- get proper starting after/before when wheel-zooming happens continuously (important for magic mouse)
- when wheel-scrolling, update chart also before fetch is resolved, to have better responsiveness

IMO this needs more work in the future, created https://github.com/netdata/cloud-frontend/issues/3613 for reference