### PR TITLE
Fix wheel scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "easy-pie-chart": "^2.1.7",
     "gaugeJS": "^1.3.7",
     "md5": "^2.3.0",
-    "throttle-debounce": "^3.0.1"
+    "throttle-debounce": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",
@@ -78,6 +78,6 @@
     "easy-pie-chart": "^2.1.7",
     "gaugeJS": "^1.3.7",
     "md5": "^2.3.0",
-    "throttle-debounce": "^5.0.0"
+    "throttle-debounce": "^3.0.1"
   }
 }

--- a/src/chartLibraries/dygraph/index.js
+++ b/src/chartLibraries/dygraph/index.js
@@ -94,7 +94,7 @@ export default (sdk, chart) => {
         touchmove: executeLatest.add((...args) => chartUI.trigger("touchmove", ...args)),
         touchend: executeLatest.add((...args) => chartUI.trigger("touchend", ...args)),
         dblclick: executeLatest.add((...args) => chartUI.trigger("dblclick", ...args)),
-        wheel: executeLatest.add((...args) => chartUI.trigger("wheel", ...args)),
+        wheel: (...args) => chartUI.trigger("wheel", ...args),
       },
 
       strokeBorderWidth: 0,

--- a/src/chartLibraries/dygraph/navigation/generic.js
+++ b/src/chartLibraries/dygraph/navigation/generic.js
@@ -30,7 +30,7 @@ export default chartUI => {
     })
   }
 
-  const onZoom = (event, g) => {
+  const onZoom = (event, dygraph) => {
     if (!event.shiftKey && !event.altKey) return
 
     event.preventDefault()
@@ -43,8 +43,8 @@ export default chartUI => {
       const increment = delta * zoomInPercentage
       const [afterIncrement, beforeIncrement] = [increment * bias, increment * (1 - bias)]
 
-      const after = Math.round(afterAxis + afterIncrement) / 1000
-      const before = Math.round(beforeAxis - beforeIncrement) / 1000
+      const after = Math.round((afterAxis + afterIncrement) / 1000)
+      const before = Math.round((beforeAxis - beforeIncrement) / 1000)
 
       chartUI.chart.moveX(after, before)
     }
@@ -58,13 +58,18 @@ export default chartUI => {
       return w == 0 ? 0 : x / w
     }
 
-    const normal = event.detail ? event.detail * -1 : event.deltaY * 2
+    const normalDef =
+      typeof event.wheelDelta === "number" && !Number.isNaN(event.wheelDelta)
+        ? event.wheelDelta / 40
+        : event.deltaY * -1.2
+
+    const normal = event.detail ? event.detail * -1 : normalDef
     const percentage = normal / 50
 
     if (!event.offsetX) event.offsetX = event.layerX - event.target.offsetLeft
-    const xPct = offsetToPercentage(g, event.offsetX)
+    const xPct = offsetToPercentage(dygraph, event.offsetX)
 
-    zoom(g, percentage, xPct)
+    zoom(dygraph, percentage, xPct)
   }
 
   const unregister = chartUI

--- a/src/chartLibraries/dygraph/navigation/generic.js
+++ b/src/chartLibraries/dygraph/navigation/generic.js
@@ -47,7 +47,7 @@ export default chartUI => {
       bias = bias || 0.5
       const [afterAxis, beforeAxis] = g.xAxisRange()
 
-      const delta = afterAxis - beforeAxis
+      const delta = beforeAxis - afterAxis
       const increment = delta * zoomInPercentage
       const [afterIncrement, beforeIncrement] = [increment * bias, increment * (1 - bias)]
 

--- a/src/chartLibraries/dygraph/navigation/generic.js
+++ b/src/chartLibraries/dygraph/navigation/generic.js
@@ -1,3 +1,6 @@
+import { debounce } from "throttle-debounce"
+import limitRange from "@/helpers/limitRange"
+
 export default chartUI => {
   const updateNavigation = (
     navigation,
@@ -30,10 +33,9 @@ export default chartUI => {
     })
   }
 
-  const getTime = seconds => {
-    if (seconds > 0) return seconds * 1000
-    return Date.now() + seconds * 1000
-  }
+  const moveXDebounced = debounce(500, (chart, fixedAfter, fixedBefore) => {
+    chart.moveX(fixedAfter, fixedBefore)
+  })
 
   const onZoom = (event, dygraph) => {
     if (!event.shiftKey && !event.altKey) return
@@ -43,18 +45,27 @@ export default chartUI => {
 
     const zoom = (g, zoomInPercentage, bias) => {
       bias = bias || 0.5
-      const attributes = chartUI.chart.getAttributes()
-      const afterAxis = getTime(attributes.after)
-      const beforeAxis = getTime(attributes.before)
+      const [afterAxis, beforeAxis] = g.xAxisRange()
+
       const delta = afterAxis - beforeAxis
       const increment = delta * zoomInPercentage
       const [afterIncrement, beforeIncrement] = [increment * bias, increment * (1 - bias)]
 
-      const after = Math.round((afterAxis + afterIncrement) / 1000)
-      const before = Math.round((beforeAxis - beforeIncrement) / 1000)
+      const afterSeconds = Math.round((afterAxis + afterIncrement) / 1000)
+      const beforeSeconds = Math.round((beforeAxis - beforeIncrement) / 1000)
 
-      chartUI.chart.getUI().render()
-      chartUI.chart.moveX(after, before)
+      const { fixedAfter, fixedBefore } = limitRange({
+        after: afterSeconds,
+        before: beforeSeconds,
+      })
+      if (fixedAfter === afterAxis && fixedBefore === beforeAxis) {
+        return
+      }
+
+      moveXDebounced(chartUI.chart, fixedAfter, fixedBefore)
+      dygraph.updateOptions({
+        dateWindow: [fixedAfter * 1000, fixedBefore * 1000],
+      })
     }
 
     const offsetToPercentage = (g, offsetX) => {

--- a/src/chartLibraries/dygraph/navigation/generic.js
+++ b/src/chartLibraries/dygraph/navigation/generic.js
@@ -30,6 +30,11 @@ export default chartUI => {
     })
   }
 
+  const getTime = seconds => {
+    if (seconds > 0) return seconds * 1000
+    return Date.now() + seconds * 1000
+  }
+
   const onZoom = (event, dygraph) => {
     if (!event.shiftKey && !event.altKey) return
 
@@ -38,7 +43,9 @@ export default chartUI => {
 
     const zoom = (g, zoomInPercentage, bias) => {
       bias = bias || 0.5
-      const [afterAxis, beforeAxis] = g.xAxisRange()
+      const attributes = chartUI.chart.getAttributes()
+      const afterAxis = getTime(attributes.after)
+      const beforeAxis = getTime(attributes.before)
       const delta = afterAxis - beforeAxis
       const increment = delta * zoomInPercentage
       const [afterIncrement, beforeIncrement] = [increment * bias, increment * (1 - bias)]
@@ -46,6 +53,7 @@ export default chartUI => {
       const after = Math.round((afterAxis + afterIncrement) / 1000)
       const before = Math.round((beforeAxis - beforeIncrement) / 1000)
 
+      chartUI.chart.getUI().render()
       chartUI.chart.moveX(after, before)
     }
 

--- a/src/helpers/limitRange.js
+++ b/src/helpers/limitRange.js
@@ -1,0 +1,22 @@
+const minDuration = 60
+
+const limitRange = ({ after, before }) => {
+  const wantedDuration = Math.round(before - after)
+  if (wantedDuration <= minDuration) {
+    const diff = minDuration - wantedDuration
+    const halfDiff = Math.floor(diff / 2)
+
+    const remainder = diff % 2
+    return {
+      fixedAfter: after - halfDiff - remainder,
+      fixedBefore: before + halfDiff,
+    }
+  }
+
+  return {
+    fixedAfter: after,
+    fixedBefore: before,
+  }
+}
+
+export default limitRange

--- a/src/helpers/limitRange.test.js
+++ b/src/helpers/limitRange.test.js
@@ -1,6 +1,5 @@
 import limitRange from "./limitRange"
 
-// const now = Math.floor(Date.now() / 1000)
 const date = 1657640000
 
 describe("limitRange", () => {

--- a/src/helpers/limitRange.test.js
+++ b/src/helpers/limitRange.test.js
@@ -1,0 +1,27 @@
+import limitRange from "./limitRange"
+
+// const now = Math.floor(Date.now() / 1000)
+const date = 1657640000
+
+describe("limitRange", () => {
+  it("should return the same range when duration is 60 seconds or more", () => {
+    expect(limitRange({ after: date - 60, before: date })).toEqual({
+      fixedAfter: date - 60,
+      fixedBefore: date,
+    })
+    expect(limitRange({ after: date - 120, before: date })).toEqual({
+      fixedAfter: date - 120,
+      fixedBefore: date,
+    })
+  })
+  it("should now allow duration less than 60 sec", () => {
+    expect(limitRange({ after: date - 59, before: date })).toEqual({
+      fixedAfter: date - 60,
+      fixedBefore: date,
+    })
+    expect(limitRange({ after: date - 58, before: date })).toEqual({
+      fixedAfter: date - 59,
+      fixedBefore: date + 1,
+    })
+  })
+})

--- a/src/helpers/makeExecuteLatest/index.js
+++ b/src/helpers/makeExecuteLatest/index.js
@@ -2,6 +2,7 @@ export default () => {
   const ids = new Set()
 
   return {
+    addSync: callback => (...args) => callback(...args),
     add: callback => {
       let id
       return (...args) => {

--- a/src/sdk/makeNode.js
+++ b/src/sdk/makeNode.js
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid"
 import makeListeners from "@/helpers/makeListeners"
 import makePristine from "@/helpers/makePristine"
+import limitRange from "@/helpers/limitRange"
 import pristineComposite, { pristineCompositeKey } from "./pristineComposite"
 import makeIntls from "./makeIntls"
 
@@ -138,12 +139,9 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
   }
 
   const moveX = (after, before) => {
-    if (after > 0 && before - after < 60) {
-      // Fallback to 1 minute
-      after = before - 60
-    }
+    const { fixedAfter, fixedBefore } = limitRange({ after, before })
 
-    sdk.trigger("moveX", instance, Math.floor(after), Math.ceil(before))
+    sdk.trigger("moveX", instance, Math.floor(fixedAfter), Math.ceil(fixedBefore))
   }
 
   const zoomX = multiplier => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13408,6 +13408,11 @@ throttle-debounce@3.0.1, throttle-debounce@^3.0.1:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
+throttle-debounce@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.0.tgz#a17a4039e82a2ed38a5e7268e4132d6960d41933"
+  integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
+
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13408,11 +13408,6 @@ throttle-debounce@3.0.1, throttle-debounce@^3.0.1:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
-throttle-debounce@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.0.tgz#a17a4039e82a2ed38a5e7268e4132d6960d41933"
-  integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
-
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"


### PR DESCRIPTION
- fixed direction of scrolling
- use the same logic for handling mouse events as in dashboard
- debounce callbacks to refresh global date-range and fetch
- but - update charts immediately
- fix event.preventDefault() - we were calling it in setTimeout() which wasn't stopping propagation and we had unwanted scroll behaviour
- moved handling to synchronous - @jjtsou you were right that omitting `executeLatest` in the handler can cause performance problems. But it is needed to fix preventDefault() problem, and also to properly sum all mouse-wheel offsets (so if you make multiple events in a row, all of them are taken into account). To avoid the performance problem, i don't call fetching immediately (but debounce it), the only synchronous effect scrolling has is updating the single dygraph chart (which is quite fast). This is actually how dashboard works, too, btw.