### PR TITLE
fix: length of result payload of getDataLength

### DIFF
--- a/src/sdk/makeChart.js
+++ b/src/sdk/makeChart.js
@@ -119,8 +119,10 @@ export default ({
     return { labels: ["time", "sum"], data }
   }
 
-  const getDataLength = ({ result } = {}) =>
-    Array.isArray(result) ? result.length : result.data?.length || 0
+  const getDataLength = payload => {
+    const { result } = payload || {}
+    return Array.isArray(result) ? result.length : result.data?.length || 0
+  }
 
   const doneFetch = (nextRawPayload, { errored = false, error = null } = {}) => {
     if (!errored) backoffMs = 0


### PR DESCRIPTION
This PR resolves [Cloud Frontend #3765](https://github.com/netdata/cloud-frontend/issues/3765)

#### Solution
Initialise `result` constant after getting `payload` argument on `getDataLength`