### PR TITLE
Filter dimensions name fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "0.5.40",
+  "version": "0.5.41",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/src/components/line/filterToolbox/dimensions.js
+++ b/src/components/line/filterToolbox/dimensions.js
@@ -9,7 +9,12 @@ import Icon from "@/components/icon"
 import Label from "./label"
 
 const getItems = dimensions =>
-  dimensions ? ["all", ...Object.keys(dimensions)].map(value => ({ value })) : [{ value: "all" }]
+  dimensions
+    ? ["all", ...Object.keys(dimensions)].map(value => ({
+        label: dimensions[value]?.name || value,
+        value,
+      }))
+    : [{ value: "all" }]
 
 const getLabel = value => {
   if (value.length === 0) return `All dimensions`
@@ -23,7 +28,7 @@ const CheckboxIcon = props => {
 
 const iconProps = { as: CheckboxIcon }
 
-const Item = ({ item: { value }, value: selectedValues, onItemClick }) => {
+const Item = ({ item: { label, value }, value: selectedValues, onItemClick }) => {
   const isAll = value === "all"
   const checked = selectedValues.includes(value) || (isAll && selectedValues.length === 0)
 
@@ -33,7 +38,7 @@ const Item = ({ item: { value }, value: selectedValues, onItemClick }) => {
         iconProps={iconProps}
         checked={checked}
         onChange={() => onItemClick(value)}
-        label={<TextSmall>{isAll ? "All dimensions" : value}</TextSmall>}
+        label={<TextSmall>{isAll ? "All dimensions" : label || value}</TextSmall>}
       />
     </ItemContainer>
   )

--- a/src/components/line/filterToolbox/dimensions.js
+++ b/src/components/line/filterToolbox/dimensions.js
@@ -16,9 +16,12 @@ const getItems = dimensions =>
       }))
     : [{ value: "all" }]
 
-const getLabel = value => {
+const getLabel = (value, items) => {
   if (value.length === 0) return `All dimensions`
-  if (value.length === 1) return value[0]
+  if (value.length === 1) {
+    const item = items.find(({ value: itemValue }) => value[0] === itemValue)
+    return item?.label || value[0]
+  }
   return `${value.length} dimensions`
 }
 
@@ -63,7 +66,7 @@ const Dimensions = ({ labelProps, ...rest }) => {
 
   const options = useMemo(() => getItems(dimensions), [value, dimensions])
 
-  const label = getLabel(value)
+  const label = getLabel(value, options)
 
   return (
     <Menu


### PR DESCRIPTION
issue: https://github.com/netdata/cloud-frontend/issues/3771

We've been using dimension ids instead of names in filter dropdown. Switched it to `name`, both for dropdown header and individual items

before:
![image](https://user-images.githubusercontent.com/5786722/188858620-295c345f-84b7-434a-a757-d1fce96f9a6c.png)

after:
![image](https://user-images.githubusercontent.com/5786722/188858680-6ab64fec-e83c-4420-8439-cfb2a1344842.png)
