### PR TITLE
Fix stacked y axis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/src/chartLibraries/dygraph/index.js
+++ b/src/chartLibraries/dygraph/index.js
@@ -227,7 +227,8 @@ export default (sdk, chart) => {
     const smooth = line && !sparkline
 
     const strokeWidth = sparkline ? 0 : stacked ? 0.1 : smooth ? 1.5 : 0.7
-    const { dimensions, selectedDimensions } = chart.getAttributes()
+    const { selectedDimensions } = chart.getAttributes()
+    const { dimensionIds } = chart.getPayload()
 
     return {
       stackedGraph: stacked,
@@ -238,7 +239,7 @@ export default (sdk, chart) => {
       includeZero:
         includeZero ||
         (stacked &&
-          dimensions?.length !== 1 &&
+          dimensionIds?.length > 1 &&
           (!selectedDimensions || selectedDimensions.length > 1)),
       stackedGraphNaNFill: "none",
       plotter: (smooth && window.smoothPlotter) || null,

--- a/src/chartLibraries/dygraph/index.js
+++ b/src/chartLibraries/dygraph/index.js
@@ -238,7 +238,7 @@ export default (sdk, chart) => {
       includeZero:
         includeZero ||
         (stacked &&
-          dimensions?.length > 1 &&
+          dimensions?.length !== 1 &&
           (!selectedDimensions || selectedDimensions.length > 1)),
       stackedGraphNaNFill: "none",
       plotter: (smooth && window.smoothPlotter) || null,

--- a/src/helpers/mergeArrays.js
+++ b/src/helpers/mergeArrays.js
@@ -1,6 +1,6 @@
 import deepEqual from "./deepEqual"
 
-const mergeMemoizedNodes = (prev, next) => {
+const mergeArrays = (prev, next) => {
   if (!prev) return next
   if (deepEqual(prev, next)) return prev
 
@@ -17,4 +17,4 @@ const mergeMemoizedNodes = (prev, next) => {
   return results
 }
 
-export default mergeMemoizedNodes
+export default mergeArrays

--- a/src/sdk/makeChart.js
+++ b/src/sdk/makeChart.js
@@ -11,7 +11,7 @@ import makeFilterControllers from "./filters/makeControllers"
 import makeGetUnitSign from "./makeGetUnitSign"
 import camelizePayload from "./camelizePayload"
 import initialMetadata from "./initialMetadata"
-import mergeMemoizedNodes from "@/helpers/mergeMemoizedNodes"
+import mergeArrays from "@/helpers/mergeArrays"
 
 const maxBackoffMs = 30 * 1000
 
@@ -135,7 +135,7 @@ export default ({
     const { dimensionIds, metadata, ...restPayload } = nextPayloadTransformed
 
     const prevPayload = nextPayload
-    const allNodes = mergeMemoizedNodes(prevPayload?.allNodes, nextPayloadTransformed.nodes)
+    const allNodes = mergeArrays(prevPayload?.allNodes, nextPayloadTransformed.nodes)
     if (deepEqual(payload.dimensionIds, dimensionIds)) {
       nextPayload = {
         ...initialPayload,


### PR DESCRIPTION
related to https://github.com/netdata/netdata-cloud/issues/608

use payload.dimensionIds instead of attributes.dimensions to calculate includeZero - because `attributes.dimensions` doesn't change when grouping (ie. the dimension from chart perspective) changes