### PR TITLE
Update default group-by for nvme charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/src/sdk/filters/getGroupBy.js
+++ b/src/sdk/filters/getGroupBy.js
@@ -19,6 +19,20 @@ const byChartDefaultGroupBy = {
   "httpcheck.status": "_collect_job",
   "httpcheck.response_length": "_collect_job",
   "httpcheck.response_time": "_collect_job",
+  "nvme.device_estimated_endurance_perc": "device",
+  "nvme.device_available_spare_perc": "device",
+  "nvme.device_composite_temperature": "device",
+  "nvme.device_power_cycles_count": "device",
+  "nvme.device_power_on_time": "device",
+  "nvme.device_unsafe_shutdowns_count": "device",
+  "nvme.device_media_errors_rate": "device",
+  "nvme.device_error_log_entries_rate": "device",
+  "nvme.device_warning_composite_temperature_time": "device",
+  "nvme.device_critical_composite_temperature_time": "device",
+  "nvme.device_thermal_mgmt_temp1_transitions_rate": "device",
+  "nvme.device_thermal_mgmt_temp2_transitions_rate": "device",
+  "nvme.device_thermal_mgmt_temp1_time": "device",
+  "nvme.device_thermal_mgmt_temp2_time": "device",
 }
 
 const getDefaultGroupBy = chart => {


### PR DESCRIPTION
Set default group by for all NVMe charts to "device" except for the following two charts which provide more value when grouped by dimension.

"nvme.device_critical_warnings_state"
"nvme.device_io_transferred_count"