### PR TITLE
increase opacity for toolbox on hovered chart

### DIFF
--- a/src/components/line/toolbox/index.js
+++ b/src/components/line/toolbox/index.js
@@ -16,17 +16,14 @@ const Container = styled(Flex).attrs({
   gap: 1,
   round: true,
   border: { side: "all", color: "borderSecondary" },
-  opacity: "weak",
 })`
   position: absolute;
   top: 8px;
   right: 8px;
-  opacity: 0.7;
   background: ${getRgbColor("elementBackground", 0.5)};
 
   &:hover {
     background: ${getColor("elementBackground")};
-    opacity: 1;
   }
 `
 


### PR DESCRIPTION
https://github.com/netdata/netdata-cloud/issues/648
cc @christophidesp 

before:
![image](https://user-images.githubusercontent.com/5786722/205679186-34aa6653-cec8-4bf1-836c-d790b320bd63.png)

![image](https://user-images.githubusercontent.com/5786722/205679285-3c7dacb9-719a-482f-b2eb-0d61c93d726a.png)

![image](https://user-images.githubusercontent.com/5786722/205681480-5229b810-8135-4f25-9dad-1fd16debee82.png)


after:
![image](https://user-images.githubusercontent.com/5786722/205678660-c236b5b7-f5cb-4624-ad61-d49c333253c6.png)

![image](https://user-images.githubusercontent.com/5786722/205681080-4eeb4db7-8e21-4dd3-8611-a7c1fbe52844.png)

![image](https://user-images.githubusercontent.com/5786722/205681270-7bcf45a5-6f1f-4fef-8390-62a29ffc7bba.png)
