### PR TITLE
fix plugin info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "index.js",
   "module": "es6/index.js",

--- a/src/components/line/details/context.js
+++ b/src/components/line/details/context.js
@@ -16,8 +16,8 @@ const Info = ({ title, children }) => (
 )
 
 const Context = () => {
-  const { chartLabels, context } = useMetadata()
-  const plugin = chartLabels?._collect_plugin?.[0]
+  const { chartLabels, context, plugin } = useMetadata()
+  const pluginText = plugin || chartLabels?._collect_plugin?.[0]
 
   return (
     <Row
@@ -26,7 +26,7 @@ const Context = () => {
       color="key"
       data-testid="cartDetails-context"
     >
-      <Info title="Plugin">{plugin}</Info>
+      <Info title="Plugin">{pluginText}</Info>
       <Info title="Context">{context}</Info>
     </Row>
   )

--- a/src/components/line/details/context.js
+++ b/src/components/line/details/context.js
@@ -16,7 +16,8 @@ const Info = ({ title, children }) => (
 )
 
 const Context = () => {
-  const { plugin, context } = useMetadata()
+  const { chartLabels, context } = useMetadata()
+  const plugin = chartLabels?._collect_plugin?.[0]
 
   return (
     <Row


### PR DESCRIPTION
display plugin from chartLabels instead of metadata (where it is no longer present)

https://github.com/netdata/netdata-cloud/issues/634