### PR TITLE
fix(filters): on groupBy update get default dimensions

### DIFF
--- a/src/components/line/filterToolbox/groupBy.js
+++ b/src/components/line/filterToolbox/groupBy.js
@@ -53,7 +53,7 @@ const GroupBy = ({ labelProps }) => {
       onChange={chart.updateGroupByAttribute}
       items={items}
       data-track={chart.track("groupBy")}
-      dropProps={{ align: { top: "bottom", left: "left" }, "data-toolbox": true }}
+      dropProps={{ align: { top: "bottom", left: "left" }, "data-toolbox": true, width: { min: "130px" } }}
     >
       <Label
         secondaryLabel="Group by"

--- a/src/sdk/filters/getDimensions.js
+++ b/src/sdk/filters/getDimensions.js
@@ -47,8 +47,9 @@ export default (chart, groupBy) => {
   const { dimensions: allDimensions, id, chartType } = chart.getMetadata()
   const dimensionsArray =
     !allDimensions || !Object.keys(allDimensions).length ? [] : Object.keys(allDimensions)
+  const prevDimensions = chart.getAttribute("dimensions")
 
-  if (groupBy === "dimension") return []
+  if (groupBy === "dimension" || !prevDimensions?.length) return []
 
   if (groupBy in groupsWithCustomLogic) {
     if (id in byNodeDefaultDimensions) return [byNodeDefaultDimensions[id]]


### PR DESCRIPTION
This PR resolves issue [Netdata Cloud #718](https://github.com/netdata/netdata-cloud/issues/718)

#### Solution
* On `groupBy` update prior to updating chart attributes (along with dimensions) first check if the user has any dimensions selected and if not provide an empty list of dimensions, in order to avoid breaking the filters UI by providing all the chart dimensions as the selected ones, instead of just having "All dimensions" as the selected value.
* Update `groupBy` menu width to have a min limit, in order for it not to "break" when the user's choice is as sort as `cpu`, which renders a small dropdown that cuts larger options.


Uploading Screen Recording 2023-03-10 at 13.34.44.mov…

