### PR TITLE
Use extracted prefixes from UCUM units

### DIFF
--- a/src/units.json
+++ b/src/units.json
@@ -1,4 +1,200 @@
 {
+  "prefixes": {
+    "Y": {
+      "symbol": "Y",
+      "name": "yotta",
+      "print_symbol": "Y",
+      "value": 1e+24,
+      "is_binary": false
+    },
+    "Z": {
+      "symbol": "Z",
+      "name": "zetta",
+      "print_symbol": "Z",
+      "value": 1e+21,
+      "is_binary": false
+    },
+    "E": {
+      "symbol": "E",
+      "name": "exa",
+      "print_symbol": "E",
+      "value": 1e+18,
+      "is_binary": false
+    },
+    "P": {
+      "symbol": "P",
+      "name": "peta",
+      "print_symbol": "P",
+      "value": 1000000000000000.0,
+      "is_binary": false
+    },
+    "T": {
+      "symbol": "T",
+      "name": "tera",
+      "print_symbol": "T",
+      "value": 1000000000000.0,
+      "is_binary": false
+    },
+    "G": {
+      "symbol": "G",
+      "name": "giga",
+      "print_symbol": "G",
+      "value": 1000000000.0,
+      "is_binary": false
+    },
+    "M": {
+      "symbol": "M",
+      "name": "mega",
+      "print_symbol": "M",
+      "value": 1000000.0,
+      "is_binary": false
+    },
+    "k": {
+      "symbol": "k",
+      "name": "kilo",
+      "print_symbol": "k",
+      "value": 1000.0,
+      "is_binary": false
+    },
+    "h": {
+      "symbol": "h",
+      "name": "hecto",
+      "print_symbol": "h",
+      "value": 100.0,
+      "is_binary": false
+    },
+    "da": {
+      "symbol": "da",
+      "name": "deka",
+      "print_symbol": "da",
+      "value": 10.0,
+      "is_binary": false
+    },
+    "d": {
+      "symbol": "d",
+      "name": "deci",
+      "print_symbol": "d",
+      "value": 0.1,
+      "is_binary": false
+    },
+    "c": {
+      "symbol": "c",
+      "name": "centi",
+      "print_symbol": "c",
+      "value": 0.01,
+      "is_binary": false
+    },
+    "m": {
+      "symbol": "m",
+      "name": "milli",
+      "print_symbol": "m",
+      "value": 0.001,
+      "is_binary": false
+    },
+    "u": {
+      "symbol": "u",
+      "name": "micro",
+      "print_symbol": "\u03bc",
+      "value": 1e-06,
+      "is_binary": false
+    },
+    "n": {
+      "symbol": "n",
+      "name": "nano",
+      "print_symbol": "n",
+      "value": 1e-09,
+      "is_binary": false
+    },
+    "p": {
+      "symbol": "p",
+      "name": "pico",
+      "print_symbol": "p",
+      "value": 1e-12,
+      "is_binary": false
+    },
+    "f": {
+      "symbol": "f",
+      "name": "femto",
+      "print_symbol": "f",
+      "value": 1e-15,
+      "is_binary": false
+    },
+    "a": {
+      "symbol": "a",
+      "name": "atto",
+      "print_symbol": "a",
+      "value": 1e-18,
+      "is_binary": false
+    },
+    "z": {
+      "symbol": "z",
+      "name": "zepto",
+      "print_symbol": "z",
+      "value": 1e-21,
+      "is_binary": false
+    },
+    "y": {
+      "symbol": "y",
+      "name": "yocto",
+      "print_symbol": "y",
+      "value": 1e-24,
+      "is_binary": false
+    },
+    "Ki": {
+      "symbol": "Ki",
+      "name": "kibi",
+      "print_symbol": "Ki",
+      "value": 1024.0,
+      "is_binary": true
+    },
+    "Mi": {
+      "symbol": "Mi",
+      "name": "mebi",
+      "print_symbol": "Mi",
+      "value": 1048576.0,
+      "is_binary": true
+    },
+    "Gi": {
+      "symbol": "Gi",
+      "name": "gibi",
+      "print_symbol": "Gi",
+      "value": 1073741824.0,
+      "is_binary": true
+    },
+    "Ti": {
+      "symbol": "Ti",
+      "name": "tebi",
+      "print_symbol": "Ti",
+      "value": 1099511627776.0,
+      "is_binary": true
+    }
+  },
+  "decimal_prefixes": {
+    "K": {
+      "symbol": "K",
+      "name": "thousand",
+      "print_symbol": "K",
+      "value": 1000.0
+    },
+    "M": {
+      "symbol": "M",
+      "name": "million",
+      "print_symbol": "M",
+      "value": 1000000.0
+    },
+    "B": {
+      "symbol": "B",
+      "name": "billion",
+      "print_symbol": "B",
+      "value": 1000000000.0
+    },
+    "T": {
+      "symbol": "T",
+      "name": "trillion",
+      "print_symbol": "T",
+      "value": 1000000000000.0
+    }
+  },
   "units": {
     "%": {
       "symbol": "%",
@@ -6,7 +202,8 @@
       "print_symbol": "%",
       "is_metric": false,
       "is_special": false,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     },
     "1": {
       "symbol": "1",
@@ -14,7 +211,8 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "A": {
       "symbol": "A",
@@ -22,7 +220,8 @@
       "print_symbol": "A",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "A.h": {
       "symbol": "A.h",
@@ -30,23 +229,17 @@
       "print_symbol": "Ah",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
-    "Bit": {
-      "symbol": "Bit",
-      "name": "Bit",
-      "print_symbol": "Bit",
+    "B[mW]": {
+      "symbol": "B[mW]",
+      "name": "bel milliwatt",
+      "print_symbol": "B(mW)",
       "is_metric": true,
-      "is_special": false,
-      "is_additive": true
-    },
-    "Bit/s": {
-      "symbol": "Bit/s",
-      "name": "Bit per second",
-      "print_symbol": "Bit/s",
-      "is_metric": true,
-      "is_special": false,
-      "is_additive": true
+      "is_special": true,
+      "is_additive": false,
+      "is_binary": false
     },
     "By": {
       "symbol": "By",
@@ -54,7 +247,8 @@
       "print_symbol": "B",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true
     },
     "By/s": {
       "symbol": "By/s",
@@ -62,15 +256,26 @@
       "print_symbol": "B/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true
+    },
+    "By/{operation}": {
+      "symbol": "By/{operation}",
+      "name": "byte per operation",
+      "print_symbol": "B/operation",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": true
     },
     "Cel": {
       "symbol": "Cel",
       "name": "degree Celsius",
       "print_symbol": "\u00b0C",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": true,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     },
     "GiBy": {
       "symbol": "GiBy",
@@ -78,15 +283,10 @@
       "print_symbol": "GiB",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
-    },
-    "GiBy/s": {
-      "symbol": "GiBy/s",
-      "name": "gibibyte per second",
-      "print_symbol": "GiB/s",
-      "is_metric": true,
-      "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "By",
+      "prefix_symbol": "Gi"
     },
     "Hz": {
       "symbol": "Hz",
@@ -94,7 +294,8 @@
       "print_symbol": "Hz",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "J": {
       "symbol": "J",
@@ -102,7 +303,8 @@
       "print_symbol": "J",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "KiBy": {
       "symbol": "KiBy",
@@ -110,7 +312,10 @@
       "print_symbol": "KiB",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "By",
+      "prefix_symbol": "Ki"
     },
     "KiBy/s": {
       "symbol": "KiBy/s",
@@ -118,7 +323,10 @@
       "print_symbol": "KiB/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "By/s",
+      "prefix_symbol": "Ki"
     },
     "KiBy/{operation}": {
       "symbol": "KiBy/{operation}",
@@ -126,7 +334,10 @@
       "print_symbol": "KiB/operation",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "By/{operation}",
+      "prefix_symbol": "Ki"
     },
     "Kibit": {
       "symbol": "Kibit",
@@ -134,7 +345,10 @@
       "print_symbol": "Kibit",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "bit",
+      "prefix_symbol": "Ki"
     },
     "Kibit/s": {
       "symbol": "Kibit/s",
@@ -142,7 +356,10 @@
       "print_symbol": "Kibit/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "bit/s",
+      "prefix_symbol": "Ki"
     },
     "MHz": {
       "symbol": "MHz",
@@ -150,15 +367,10 @@
       "print_symbol": "MHz",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
-    },
-    "GHz": {
-      "symbol": "GHz",
-      "name": "gigahertz",
-      "print_symbol": "GHz",
-      "is_metric": true,
-      "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "Hz",
+      "prefix_symbol": "M"
     },
     "MiBy": {
       "symbol": "MiBy",
@@ -166,7 +378,10 @@
       "print_symbol": "MiB",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "By",
+      "prefix_symbol": "Mi"
     },
     "MiBy/s": {
       "symbol": "MiBy/s",
@@ -174,7 +389,10 @@
       "print_symbol": "MiB/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "By/s",
+      "prefix_symbol": "Mi"
     },
     "Mibit/s": {
       "symbol": "Mibit/s",
@@ -182,7 +400,10 @@
       "print_symbol": "Mibit/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "bit/s",
+      "prefix_symbol": "Mi"
     },
     "V": {
       "symbol": "V",
@@ -190,7 +411,8 @@
       "print_symbol": "V",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "W": {
       "symbol": "W",
@@ -198,7 +420,8 @@
       "print_symbol": "W",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "W.h": {
       "symbol": "W.h",
@@ -206,7 +429,8 @@
       "print_symbol": "Wh",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "[CPU]": {
       "symbol": "[CPU]",
@@ -214,7 +438,8 @@
       "print_symbol": "CPU",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true
     },
     "[degF]": {
       "symbol": "[degF]",
@@ -222,7 +447,8 @@
       "print_symbol": "\u00b0F",
       "is_metric": false,
       "is_special": true,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     },
     "[ppm]": {
       "symbol": "[ppm]",
@@ -230,7 +456,26 @@
       "print_symbol": "ppm",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "bit": {
+      "symbol": "bit",
+      "name": "bit",
+      "print_symbol": "bit",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": true
+    },
+    "bit/s": {
+      "symbol": "bit/s",
+      "name": "bit per second",
+      "print_symbol": "bit/s",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": true
     },
     "c[CPU]": {
       "symbol": "c[CPU]",
@@ -238,7 +483,10 @@
       "print_symbol": "cCPU",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "[CPU]",
+      "prefix_symbol": "c"
     },
     "dB[mW]": {
       "symbol": "dB[mW]",
@@ -246,7 +494,10 @@
       "print_symbol": "dB(mW)",
       "is_metric": true,
       "is_special": true,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false,
+      "bare_symbol": "B[mW]",
+      "prefix_symbol": "d"
     },
     "h": {
       "symbol": "h",
@@ -254,7 +505,8 @@
       "print_symbol": "h",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "m[CPU]": {
       "symbol": "m[CPU]",
@@ -262,7 +514,10 @@
       "print_symbol": "mCPU",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": true,
+      "bare_symbol": "[CPU]",
+      "prefix_symbol": "m"
     },
     "min": {
       "symbol": "min",
@@ -270,7 +525,8 @@
       "print_symbol": "min",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "ms": {
       "symbol": "ms",
@@ -278,7 +534,10 @@
       "print_symbol": "ms",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s",
+      "prefix_symbol": "m"
     },
     "ms/s": {
       "symbol": "ms/s",
@@ -286,7 +545,10 @@
       "print_symbol": "ms/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s/s",
+      "prefix_symbol": "m"
     },
     "ms/{operation}": {
       "symbol": "ms/{operation}",
@@ -294,7 +556,32 @@
       "print_symbol": "ms/operation",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s/{operation}",
+      "prefix_symbol": "m"
+    },
+    "ms/{request}": {
+      "symbol": "ms/{request}",
+      "name": "millisecond per request",
+      "print_symbol": "ms/request",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s/{request}",
+      "prefix_symbol": "m"
+    },
+    "ms/{run}": {
+      "symbol": "ms/{run}",
+      "name": "millisecond per run",
+      "print_symbol": "ms/run",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s/{run}",
+      "prefix_symbol": "m"
     },
     "ns": {
       "symbol": "ns",
@@ -302,7 +589,10 @@
       "print_symbol": "ns",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s",
+      "prefix_symbol": "n"
     },
     "s": {
       "symbol": "s",
@@ -310,7 +600,8 @@
       "print_symbol": "s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "s/s": {
       "symbol": "s/s",
@@ -318,7 +609,35 @@
       "print_symbol": "s/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "s/{operation}": {
+      "symbol": "s/{operation}",
+      "name": "second per operation",
+      "print_symbol": "s/operation",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
+    },
+    "s/{request}": {
+      "symbol": "s/{request}",
+      "name": "second per request",
+      "print_symbol": "s/request",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
+    },
+    "s/{run}": {
+      "symbol": "s/{run}",
+      "name": "second per run",
+      "print_symbol": "s/run",
+      "is_metric": true,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "us": {
       "symbol": "us",
@@ -326,7 +645,10 @@
       "print_symbol": "\u03bcs",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s",
+      "prefix_symbol": "u"
     },
     "us/s": {
       "symbol": "us/s",
@@ -334,23 +656,28 @@
       "print_symbol": "\u03bcs/s",
       "is_metric": true,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false,
+      "bare_symbol": "s/s",
+      "prefix_symbol": "u"
     },
     "{acquisition}/s": {
       "symbol": "{acquisition}/s",
       "name": "acquisitions per second",
       "print_symbol": "acquisitions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{action}/s": {
       "symbol": "{action}/s",
       "name": "actions per second",
       "print_symbol": "actions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{address space}": {
       "symbol": "{address space}",
@@ -358,15 +685,17 @@
       "print_symbol": "address spaces",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{answer}/s": {
       "symbol": "{answer}/s",
       "name": "answers per second",
       "print_symbol": "answers/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{array}": {
       "symbol": "{array}",
@@ -374,23 +703,26 @@
       "print_symbol": "arrays",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{assembly}/s": {
       "symbol": "{assembly}/s",
       "name": "assemblies per second",
       "print_symbol": "assemblies/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{assert}/s": {
       "symbol": "{assert}/s",
       "name": "asserts per second",
       "print_symbol": "asserts/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{association}": {
       "symbol": "{association}",
@@ -398,7 +730,8 @@
       "print_symbol": "associations",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{attempt}": {
       "symbol": "{attempt}",
@@ -406,31 +739,35 @@
       "print_symbol": "attempts",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{attempt}/s": {
       "symbol": "{attempt}/s",
       "name": "attempts per second",
       "print_symbol": "attempts/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{authentication}/s": {
       "symbol": "{authentication}/s",
       "name": "authentications per second",
       "print_symbol": "authentications/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{ban}/s": {
       "symbol": "{ban}/s",
       "name": "bans per second",
       "print_symbol": "bans/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{batch}": {
       "symbol": "{batch}",
@@ -438,23 +775,26 @@
       "print_symbol": "batches",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{batch}/s": {
       "symbol": "{batch}/s",
       "name": "batches per second",
       "print_symbol": "batches/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{bind}/s": {
       "symbol": "{bind}/s",
       "name": "binds per second",
       "print_symbol": "binds/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{blocked subscription}": {
       "symbol": "{blocked subscription}",
@@ -462,7 +802,8 @@
       "print_symbol": "blocked subscriptions",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{block}": {
       "symbol": "{block}",
@@ -470,7 +811,8 @@
       "print_symbol": "blocks",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{boolean}": {
       "symbol": "{boolean}",
@@ -478,7 +820,8 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{buffer}": {
       "symbol": "{buffer}",
@@ -486,7 +829,17 @@
       "print_symbol": "buffers",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{callback}/s": {
+      "symbol": "{callback}/s",
+      "name": "callbacks per second",
+      "print_symbol": "callbacks/s",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{call}": {
       "symbol": "{call}",
@@ -494,23 +847,26 @@
       "print_symbol": "calls",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{call}/s": {
       "symbol": "{call}/s",
       "name": "calls per second",
       "print_symbol": "calls/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{ccw}/s": {
       "symbol": "{ccw}/s",
       "name": "ccws per second",
       "print_symbol": "ccws/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{chain}": {
       "symbol": "{chain}",
@@ -518,23 +874,26 @@
       "print_symbol": "chains",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{change}/s": {
       "symbol": "{change}/s",
       "name": "changes per second",
       "print_symbol": "changes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{channel}/s": {
       "symbol": "{channel}/s",
       "name": "channels per second",
       "print_symbol": "channels/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{character}": {
       "symbol": "{character}",
@@ -542,23 +901,35 @@
       "print_symbol": "characters",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{chart}": {
+      "symbol": "{chart}",
+      "name": "charts",
+      "print_symbol": "charts",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{checkpoint}/s": {
       "symbol": "{checkpoint}/s",
       "name": "checkpoints per second",
       "print_symbol": "checkpoints/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{check}/s": {
       "symbol": "{check}/s",
       "name": "checks per second",
       "print_symbol": "checks/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{child}": {
       "symbol": "{child}",
@@ -566,7 +937,8 @@
       "print_symbol": "children",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{chunk}": {
       "symbol": "{chunk}",
@@ -574,7 +946,8 @@
       "print_symbol": "chunks",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{class}": {
       "symbol": "{class}",
@@ -582,15 +955,17 @@
       "print_symbol": "classes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{class}/s": {
       "symbol": "{class}/s",
       "name": "classes per second",
       "print_symbol": "classes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{client}": {
       "symbol": "{client}",
@@ -598,7 +973,8 @@
       "print_symbol": "clients",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{cluster}": {
       "symbol": "{cluster}",
@@ -606,15 +982,17 @@
       "print_symbol": "clusters",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{cluster}/s": {
       "symbol": "{cluster}/s",
       "name": "clusters per second",
       "print_symbol": "clusters/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{code}": {
       "symbol": "{code}",
@@ -622,7 +1000,8 @@
       "print_symbol": "codes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{collection}": {
       "symbol": "{collection}",
@@ -630,7 +1009,8 @@
       "print_symbol": "collections",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{column}": {
       "symbol": "{column}",
@@ -638,7 +1018,8 @@
       "print_symbol": "columns",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{command}": {
       "symbol": "{command}",
@@ -646,15 +1027,17 @@
       "print_symbol": "commands",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{command}/s": {
       "symbol": "{command}/s",
       "name": "commands per second",
       "print_symbol": "commands/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{commit}": {
       "symbol": "{commit}",
@@ -662,23 +1045,26 @@
       "print_symbol": "commits",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{commit}/s": {
       "symbol": "{commit}/s",
       "name": "commits per second",
       "print_symbol": "commits/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{compilation}/s": {
       "symbol": "{compilation}/s",
       "name": "compilations per second",
       "print_symbol": "compilations/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{component}": {
       "symbol": "{component}",
@@ -686,7 +1072,8 @@
       "print_symbol": "components",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{concurrent file accesses}": {
       "symbol": "{concurrent file accesses}",
@@ -694,7 +1081,8 @@
       "print_symbol": "concurrent file accesseses",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{connection}": {
       "symbol": "{connection}",
@@ -702,15 +1090,17 @@
       "print_symbol": "connections",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{connection}/s": {
       "symbol": "{connection}/s",
       "name": "connections per second",
       "print_symbol": "connections/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{consumer}": {
       "symbol": "{consumer}",
@@ -718,7 +1108,8 @@
       "print_symbol": "consumers",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{container}": {
       "symbol": "{container}",
@@ -726,23 +1117,26 @@
       "print_symbol": "containers",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{contention}/s": {
       "symbol": "{contention}/s",
       "name": "contentions per second",
       "print_symbol": "contentions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{context switch}/s": {
       "symbol": "{context switch}/s",
       "name": "context switches per second",
       "print_symbol": "context switches/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{context}": {
       "symbol": "{context}",
@@ -750,23 +1144,26 @@
       "print_symbol": "contexts",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{cookie}/s": {
       "symbol": "{cookie}/s",
       "name": "cookies per second",
       "print_symbol": "cookies/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{count}/s": {
       "symbol": "{count}/s",
       "name": "counts per second",
       "print_symbol": "counts/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{ctoken}": {
       "symbol": "{ctoken}",
@@ -774,7 +1171,8 @@
       "print_symbol": "ctokens",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{cursor}": {
       "symbol": "{cursor}",
@@ -782,15 +1180,17 @@
       "print_symbol": "cursors",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{cursor}/s": {
       "symbol": "{cursor}/s",
       "name": "cursors per second",
       "print_symbol": "cursors/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{cycle}": {
       "symbol": "{cycle}",
@@ -798,15 +1198,17 @@
       "print_symbol": "cycles",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{cycle}/s": {
       "symbol": "{cycle}/s",
       "name": "cycles per second",
       "print_symbol": "cycles/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{database}": {
       "symbol": "{database}",
@@ -814,15 +1216,17 @@
       "print_symbol": "databases",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{deadlock}/s": {
       "symbol": "{deadlock}/s",
       "name": "deadlocks per second",
       "print_symbol": "deadlocks/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{depth}": {
       "symbol": "{depth}",
@@ -830,7 +1234,8 @@
       "print_symbol": "depths",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{descriptor}": {
       "symbol": "{descriptor}",
@@ -838,7 +1243,8 @@
       "print_symbol": "descriptors",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{destination}": {
       "symbol": "{destination}",
@@ -846,7 +1252,8 @@
       "print_symbol": "destinations",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{device}": {
       "symbol": "{device}",
@@ -854,7 +1261,8 @@
       "print_symbol": "devices",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{dialog}": {
       "symbol": "{dialog}",
@@ -862,15 +1270,26 @@
       "print_symbol": "dialogs",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{dialog}/s": {
       "symbol": "{dialog}/s",
       "name": "dialogs per second",
       "print_symbol": "dialogs/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{dictionary}": {
+      "symbol": "{dictionary}",
+      "name": "dictionaries",
+      "print_symbol": "dictionaries",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{difficulty}": {
       "symbol": "{difficulty}",
@@ -878,7 +1297,17 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
+    },
+    "{dimension}": {
+      "symbol": "{dimension}",
+      "name": "dimensions",
+      "print_symbol": "dimensions",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{directory}": {
       "symbol": "{directory}",
@@ -886,15 +1315,17 @@
       "print_symbol": "directories",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{discard}/s": {
       "symbol": "{discard}/s",
       "name": "discards per second",
       "print_symbol": "discards/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{disk}": {
       "symbol": "{disk}",
@@ -902,15 +1333,17 @@
       "print_symbol": "disks",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{dispatch}/s": {
       "symbol": "{dispatch}/s",
       "name": "dispatches per second",
       "print_symbol": "dispatches/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{document}": {
       "symbol": "{document}",
@@ -918,15 +1351,17 @@
       "print_symbol": "documents",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{document}/s": {
       "symbol": "{document}/s",
       "name": "documents per second",
       "print_symbol": "documents/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{doc}": {
       "symbol": "{doc}",
@@ -934,7 +1369,8 @@
       "print_symbol": "docs",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{domain}": {
       "symbol": "{domain}",
@@ -942,39 +1378,44 @@
       "print_symbol": "domains",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{domain}/s": {
       "symbol": "{domain}/s",
       "name": "domains per second",
       "print_symbol": "domains/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{dpc}/s": {
       "symbol": "{dpc}/s",
       "name": "dpcs per second",
       "print_symbol": "dpcs/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{drop}/s": {
       "symbol": "{drop}/s",
       "name": "drops per second",
       "print_symbol": "drops/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{election}/s": {
       "symbol": "{election}/s",
       "name": "elections per second",
       "print_symbol": "elections/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{element}": {
       "symbol": "{element}",
@@ -982,7 +1423,8 @@
       "print_symbol": "elements",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{email}": {
       "symbol": "{email}",
@@ -990,7 +1432,8 @@
       "print_symbol": "emails",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{endpoint}": {
       "symbol": "{endpoint}",
@@ -998,7 +1441,8 @@
       "print_symbol": "endpoints",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{entropy}": {
       "symbol": "{entropy}",
@@ -1006,7 +1450,8 @@
       "print_symbol": "entropies",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{entry}": {
       "symbol": "{entry}",
@@ -1014,15 +1459,17 @@
       "print_symbol": "entries",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{entry}/s": {
       "symbol": "{entry}/s",
       "name": "entries per second",
       "print_symbol": "entries/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{erase}": {
       "symbol": "{erase}",
@@ -1030,7 +1477,8 @@
       "print_symbol": "erases",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{error}": {
       "symbol": "{error}",
@@ -1038,15 +1486,17 @@
       "print_symbol": "errors",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{error}/s": {
       "symbol": "{error}/s",
       "name": "errors per second",
       "print_symbol": "errors/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{event}": {
       "symbol": "{event}",
@@ -1054,15 +1504,17 @@
       "print_symbol": "events",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{event}/s": {
       "symbol": "{event}/s",
       "name": "events per second",
       "print_symbol": "events/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{exception}": {
       "symbol": "{exception}",
@@ -1070,23 +1522,26 @@
       "print_symbol": "exceptions",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{exception}/s": {
       "symbol": "{exception}/s",
       "name": "exceptions per second",
       "print_symbol": "exceptions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{expectation}/s": {
       "symbol": "{expectation}/s",
       "name": "expectations per second",
       "print_symbol": "expectations/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{failure}": {
       "symbol": "{failure}",
@@ -1094,23 +1549,26 @@
       "print_symbol": "failures",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{failure}/s": {
       "symbol": "{failure}/s",
       "name": "failures per second",
       "print_symbol": "failures/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{fail}/s": {
       "symbol": "{fail}/s",
       "name": "fails per second",
       "print_symbol": "fails/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{fault}": {
       "symbol": "{fault}",
@@ -1118,7 +1576,8 @@
       "print_symbol": "faults",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{fd}": {
       "symbol": "{fd}",
@@ -1126,7 +1585,8 @@
       "print_symbol": "fds",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{fetch}": {
       "symbol": "{fetch}",
@@ -1134,7 +1594,8 @@
       "print_symbol": "fetches",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{file descriptor}": {
       "symbol": "{file descriptor}",
@@ -1142,7 +1603,8 @@
       "print_symbol": "file descriptors",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{filesystem}": {
       "symbol": "{filesystem}",
@@ -1150,7 +1612,8 @@
       "print_symbol": "filesystems",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{file}": {
       "symbol": "{file}",
@@ -1158,31 +1621,35 @@
       "print_symbol": "files",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{file}/s": {
       "symbol": "{file}/s",
       "name": "files per second",
       "print_symbol": "files/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{filter}/s": {
       "symbol": "{filter}/s",
       "name": "filters per second",
       "print_symbol": "filters/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{finally}/s": {
       "symbol": "{finally}/s",
       "name": "finallies per second",
       "print_symbol": "finallies/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{flag}": {
       "symbol": "{flag}",
@@ -1190,7 +1657,8 @@
       "print_symbol": "flags",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{flow}": {
       "symbol": "{flow}",
@@ -1198,7 +1666,8 @@
       "print_symbol": "flows",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{flush}": {
       "symbol": "{flush}",
@@ -1206,15 +1675,17 @@
       "print_symbol": "flushes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{flush}/s": {
       "symbol": "{flush}/s",
       "name": "flushes per second",
       "print_symbol": "flushes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{fragment}": {
       "symbol": "{fragment}",
@@ -1222,15 +1693,17 @@
       "print_symbol": "fragments",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{frame}/s": {
       "symbol": "{frame}/s",
       "name": "frames per second",
       "print_symbol": "frames/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{fsm}": {
       "symbol": "{fsm}",
@@ -1238,15 +1711,17 @@
       "print_symbol": "fsms",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{gc}/s": {
       "symbol": "{gc}/s",
       "name": "gcs per second",
       "print_symbol": "gcs/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{goroutine}": {
       "symbol": "{goroutine}",
@@ -1254,15 +1729,17 @@
       "print_symbol": "goroutines",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{handler}/s": {
       "symbol": "{handler}/s",
       "name": "handlers per second",
       "print_symbol": "handlers/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{handle}": {
       "symbol": "{handle}",
@@ -1270,23 +1747,26 @@
       "print_symbol": "handles",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{handle}/s": {
       "symbol": "{handle}/s",
       "name": "handles per second",
       "print_symbol": "handles/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{handshake}/s": {
       "symbol": "{handshake}/s",
       "name": "handshakes per second",
       "print_symbol": "handshakes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{harakiri}": {
       "symbol": "{harakiri}",
@@ -1294,7 +1774,8 @@
       "print_symbol": "harakiris",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{hash table}": {
       "symbol": "{hash table}",
@@ -1302,7 +1783,8 @@
       "print_symbol": "hash tables",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{heartbeat}": {
       "symbol": "{heartbeat}",
@@ -1310,15 +1792,17 @@
       "print_symbol": "heartbeats",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{hit}/s": {
       "symbol": "{hit}/s",
       "name": "hits per second",
       "print_symbol": "hits/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{host}": {
       "symbol": "{host}",
@@ -1326,7 +1810,8 @@
       "print_symbol": "hosts",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{image}": {
       "symbol": "{image}",
@@ -1334,7 +1819,8 @@
       "print_symbol": "images",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{index}": {
       "symbol": "{index}",
@@ -1342,15 +1828,17 @@
       "print_symbol": "indices",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{index}/s": {
       "symbol": "{index}/s",
       "name": "indices per second",
       "print_symbol": "indices/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{indice}": {
       "symbol": "{indice}",
@@ -1358,7 +1846,8 @@
       "print_symbol": "indices",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{inode}": {
       "symbol": "{inode}",
@@ -1366,15 +1855,17 @@
       "print_symbol": "inodes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{instruction}/s": {
       "symbol": "{instruction}/s",
       "name": "instructions per second",
       "print_symbol": "instructions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{instruction}/{cycle}": {
       "symbol": "{instruction}/{cycle}",
@@ -1382,7 +1873,8 @@
       "print_symbol": "instructions/cycle",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{interface}": {
       "symbol": "{interface}",
@@ -1390,7 +1882,8 @@
       "print_symbol": "interfaces",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{interrupt}": {
       "symbol": "{interrupt}",
@@ -1398,15 +1891,17 @@
       "print_symbol": "interrupts",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{interrupt}/s": {
       "symbol": "{interrupt}/s",
       "name": "interrupts per second",
       "print_symbol": "interrupts/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{invoke}": {
       "symbol": "{invoke}",
@@ -1414,7 +1909,8 @@
       "print_symbol": "invokes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{iop}": {
       "symbol": "{iop}",
@@ -1422,15 +1918,17 @@
       "print_symbol": "iops",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{iop}/s": {
       "symbol": "{iop}/s",
       "name": "iops per second",
       "print_symbol": "iops/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{ip}": {
       "symbol": "{ip}",
@@ -1438,15 +1936,17 @@
       "print_symbol": "ips",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{issue}/s": {
       "symbol": "{issue}/s",
       "name": "issues per second",
       "print_symbol": "issues/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{item}": {
       "symbol": "{item}",
@@ -1454,7 +1954,8 @@
       "print_symbol": "items",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{job}": {
       "symbol": "{job}",
@@ -1462,23 +1963,26 @@
       "print_symbol": "jobs",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{job}/s": {
       "symbol": "{job}/s",
       "name": "jobs per second",
       "print_symbol": "jobs/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{join}/s": {
       "symbol": "{join}/s",
       "name": "joins per second",
       "print_symbol": "joins/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{key}": {
       "symbol": "{key}",
@@ -1486,15 +1990,17 @@
       "print_symbol": "keys",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{key}/s": {
       "symbol": "{key}/s",
       "name": "keys per second",
       "print_symbol": "keys/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{kill}": {
       "symbol": "{kill}",
@@ -1502,15 +2008,17 @@
       "print_symbol": "kills",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{kill}/s": {
       "symbol": "{kill}/s",
       "name": "kills per second",
       "print_symbol": "kills/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{leaseholder}": {
       "symbol": "{leaseholder}",
@@ -1518,7 +2026,8 @@
       "print_symbol": "leaseholders",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{lease}": {
       "symbol": "{lease}",
@@ -1526,7 +2035,8 @@
       "print_symbol": "leases",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{listener}": {
       "symbol": "{listener}",
@@ -1534,23 +2044,26 @@
       "print_symbol": "listeners",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{listener}/s": {
       "symbol": "{listener}/s",
       "name": "listeners per second",
       "print_symbol": "listeners/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{list}/s": {
       "symbol": "{list}/s",
       "name": "lists per second",
       "print_symbol": "lists/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{load}": {
       "symbol": "{load}",
@@ -1558,7 +2071,8 @@
       "print_symbol": "loads",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{lock}": {
       "symbol": "{lock}",
@@ -1566,15 +2080,17 @@
       "print_symbol": "locks",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{lock}/s": {
       "symbol": "{lock}/s",
       "name": "locks per second",
       "print_symbol": "locks/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{log2}": {
       "symbol": "{log2}",
@@ -1582,7 +2098,8 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     },
     "{login}": {
       "symbol": "{login}",
@@ -1590,39 +2107,44 @@
       "print_symbol": "logins",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{log}/s": {
       "symbol": "{log}/s",
       "name": "logs per second",
       "print_symbol": "logs/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{lookup}/s": {
       "symbol": "{lookup}/s",
       "name": "lookups per second",
       "print_symbol": "lookups/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{mac address}/s": {
       "symbol": "{mac address}/s",
       "name": "mac addresses per second",
       "print_symbol": "mac addresses/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{marshalling}/s": {
       "symbol": "{marshalling}/s",
       "name": "marshallings per second",
       "print_symbol": "marshallings/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{message}": {
       "symbol": "{message}",
@@ -1630,15 +2152,17 @@
       "print_symbol": "messages",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{message}/s": {
       "symbol": "{message}/s",
       "name": "messages per second",
       "print_symbol": "messages/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{method}": {
       "symbol": "{method}",
@@ -1646,15 +2170,26 @@
       "print_symbol": "methods",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{method}/s": {
       "symbol": "{method}/s",
       "name": "methods per second",
       "print_symbol": "methods/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{metric}": {
+      "symbol": "{metric}",
+      "name": "metrics",
+      "print_symbol": "metrics",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{migration}": {
       "symbol": "{migration}",
@@ -1662,23 +2197,35 @@
       "print_symbol": "migrations",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{miss}/s": {
       "symbol": "{miss}/s",
       "name": "misses per second",
       "print_symbol": "misses/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{model}": {
+      "symbol": "{model}",
+      "name": "models",
+      "print_symbol": "models",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{modification}/s": {
       "symbol": "{modification}/s",
       "name": "modifications per second",
       "print_symbol": "modifications/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{netsplit}": {
       "symbol": "{netsplit}",
@@ -1686,15 +2233,17 @@
       "print_symbol": "netsplits",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{netsplit}/s": {
       "symbol": "{netsplit}/s",
       "name": "netsplits per second",
       "print_symbol": "netsplits/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{node}": {
       "symbol": "{node}",
@@ -1702,7 +2251,8 @@
       "print_symbol": "nodes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{ntp mode}": {
       "symbol": "{ntp mode}",
@@ -1710,7 +2260,8 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     },
     "{object}": {
       "symbol": "{object}",
@@ -1718,15 +2269,17 @@
       "print_symbol": "objects",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{object}/s": {
       "symbol": "{object}/s",
       "name": "objects per second",
       "print_symbol": "objects/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{observation}": {
       "symbol": "{observation}",
@@ -1734,15 +2287,17 @@
       "print_symbol": "observations",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{observe}/s": {
       "symbol": "{observe}/s",
       "name": "observes per second",
       "print_symbol": "observes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{octet}": {
       "symbol": "{octet}",
@@ -1750,7 +2305,17 @@
       "print_symbol": "octets",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{opcode}": {
+      "symbol": "{opcode}",
+      "name": "opcodes",
+      "print_symbol": "opcodes",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{open socket}": {
       "symbol": "{open socket}",
@@ -1758,7 +2323,8 @@
       "print_symbol": "open sockets",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{operation}": {
       "symbol": "{operation}",
@@ -1766,23 +2332,26 @@
       "print_symbol": "operations",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{operation}/s": {
       "symbol": "{operation}/s",
       "name": "operations per second",
       "print_symbol": "operations/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{overflow}/s": {
       "symbol": "{overflow}/s",
       "name": "overflows per second",
       "print_symbol": "overflows/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{packet}": {
       "symbol": "{packet}",
@@ -1790,15 +2359,17 @@
       "print_symbol": "packets",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{packet}/s": {
       "symbol": "{packet}/s",
       "name": "packets per second",
       "print_symbol": "packets/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{page fault}": {
       "symbol": "{page fault}",
@@ -1806,15 +2377,17 @@
       "print_symbol": "page faults",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{page fault}/s": {
       "symbol": "{page fault}/s",
       "name": "page faults per second",
       "print_symbol": "page faults/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{page}": {
       "symbol": "{page}",
@@ -1822,23 +2395,26 @@
       "print_symbol": "pages",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{page}/s": {
       "symbol": "{page}/s",
       "name": "pages per second",
       "print_symbol": "pages/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{panic}/s": {
       "symbol": "{panic}/s",
       "name": "panics per second",
       "print_symbol": "panics/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{peer}": {
       "symbol": "{peer}",
@@ -1846,7 +2422,8 @@
       "print_symbol": "peers",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{pipe}": {
       "symbol": "{pipe}",
@@ -1854,7 +2431,8 @@
       "print_symbol": "pipes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{pod}": {
       "symbol": "{pod}",
@@ -1862,7 +2440,17 @@
       "print_symbol": "pods",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{point}/s": {
+      "symbol": "{point}/s",
+      "name": "points per second",
+      "print_symbol": "points/s",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{pool}": {
       "symbol": "{pool}",
@@ -1870,7 +2458,8 @@
       "print_symbol": "pools",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{prefetch}": {
       "symbol": "{prefetch}",
@@ -1878,31 +2467,26 @@
       "print_symbol": "prefetches",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{prefetch}/s": {
       "symbol": "{prefetch}/s",
       "name": "prefetches per second",
       "print_symbol": "prefetches/s",
-      "is_metric": true,
-      "is_special": false,
-      "is_additive": true
-    },
-    "{probability}": {
-      "symbol": "{probability}",
-      "name": "probabilities",
-      "print_symbol": "probabilities",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{problem}/s": {
       "symbol": "{problem}/s",
       "name": "problems per second",
       "print_symbol": "problems/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{process}": {
       "symbol": "{process}",
@@ -1910,15 +2494,17 @@
       "print_symbol": "processes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{process}/s": {
       "symbol": "{process}/s",
       "name": "processes per second",
       "print_symbol": "processes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{producer}": {
       "symbol": "{producer}",
@@ -1926,7 +2512,8 @@
       "print_symbol": "producers",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{program}": {
       "symbol": "{program}",
@@ -1934,23 +2521,26 @@
       "print_symbol": "programs",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{propertie}/s": {
       "symbol": "{propertie}/s",
       "name": "properties per second",
       "print_symbol": "properties/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{publish}/s": {
       "symbol": "{publish}/s",
       "name": "publishes per second",
       "print_symbol": "publishes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{pull}": {
       "symbol": "{pull}",
@@ -1958,15 +2548,17 @@
       "print_symbol": "pulls",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{pull}/s": {
       "symbol": "{pull}/s",
       "name": "pulls per second",
       "print_symbol": "pulls/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{query}": {
       "symbol": "{query}",
@@ -1974,23 +2566,26 @@
       "print_symbol": "queries",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{query}/s": {
       "symbol": "{query}/s",
       "name": "queries per second",
       "print_symbol": "queries/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{question}/s": {
       "symbol": "{question}/s",
       "name": "questions per second",
       "print_symbol": "questions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{queue processe}": {
       "symbol": "{queue processe}",
@@ -1998,15 +2593,17 @@
       "print_symbol": "queue processes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{queue processe}/s": {
       "symbol": "{queue processe}/s",
       "name": "queue processes per second",
       "print_symbol": "queue processes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{queue}": {
       "symbol": "{queue}",
@@ -2014,7 +2611,8 @@
       "print_symbol": "queues",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{range}": {
       "symbol": "{range}",
@@ -2022,15 +2620,17 @@
       "print_symbol": "ranges",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{read}/s": {
       "symbol": "{read}/s",
       "name": "reads per second",
       "print_symbol": "reads/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{read}/{query}": {
       "symbol": "{read}/{query}",
@@ -2038,31 +2638,35 @@
       "print_symbol": "reads/query",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{recompile}/s": {
       "symbol": "{recompile}/s",
       "name": "recompiles per second",
       "print_symbol": "recompiles/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{record}/s": {
       "symbol": "{record}/s",
       "name": "records per second",
       "print_symbol": "records/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{redirect}/s": {
       "symbol": "{redirect}/s",
       "name": "redirects per second",
       "print_symbol": "redirects/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{reduction}": {
       "symbol": "{reduction}",
@@ -2070,31 +2674,44 @@
       "print_symbol": "reductions",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{reference}": {
+      "symbol": "{reference}",
+      "name": "references",
+      "print_symbol": "references",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{referral}/s": {
       "symbol": "{referral}/s",
       "name": "referrals per second",
       "print_symbol": "referrals/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{registration}/s": {
       "symbol": "{registration}/s",
       "name": "registrations per second",
       "print_symbol": "registrations/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{rejection}/s": {
       "symbol": "{rejection}/s",
       "name": "rejections per second",
       "print_symbol": "rejections/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{relation}": {
       "symbol": "{relation}",
@@ -2102,7 +2719,8 @@
       "print_symbol": "relations",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{reorg}": {
       "symbol": "{reorg}",
@@ -2110,7 +2728,8 @@
       "print_symbol": "reorgs",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{repair}": {
       "symbol": "{repair}",
@@ -2118,7 +2737,8 @@
       "print_symbol": "repairs",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{replica}": {
       "symbol": "{replica}",
@@ -2126,7 +2746,8 @@
       "print_symbol": "replicas",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{reply}": {
       "symbol": "{reply}",
@@ -2134,23 +2755,26 @@
       "print_symbol": "replies",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{reply}/s": {
       "symbol": "{reply}/s",
       "name": "replies per second",
       "print_symbol": "replies/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{report}/s": {
       "symbol": "{report}/s",
       "name": "reports per second",
       "print_symbol": "reports/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{request}": {
       "symbol": "{request}",
@@ -2158,31 +2782,35 @@
       "print_symbol": "requests",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{request}/s": {
       "symbol": "{request}/s",
       "name": "requests per second",
       "print_symbol": "requests/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{reset}/s": {
       "symbol": "{reset}/s",
       "name": "resets per second",
       "print_symbol": "resets/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{resolution}/s": {
       "symbol": "{resolution}/s",
       "name": "resolutions per second",
       "print_symbol": "resolutions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{respawn}": {
       "symbol": "{respawn}",
@@ -2190,23 +2818,17 @@
       "print_symbol": "respawns",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
-    },
-    "{response}": {
-      "symbol": "{response}",
-      "name": "responses",
-      "print_symbol": "responses",
-      "is_metric": false,
-      "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{response}/s": {
       "symbol": "{response}/s",
       "name": "responses per second",
       "print_symbol": "responses/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{restart}": {
       "symbol": "{restart}",
@@ -2214,15 +2836,17 @@
       "print_symbol": "restarts",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{retrieval}/s": {
       "symbol": "{retrieval}/s",
       "name": "retrievals per second",
       "print_symbol": "retrievals/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{retry}": {
       "symbol": "{retry}",
@@ -2230,23 +2854,26 @@
       "print_symbol": "retries",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{retry}/s": {
       "symbol": "{retry}/s",
       "name": "retries per second",
       "print_symbol": "retries/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{reuse}/s": {
       "symbol": "{reuse}/s",
       "name": "reuses per second",
       "print_symbol": "reuses/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{rotation}/min": {
       "symbol": "{rotation}/min",
@@ -2254,7 +2881,8 @@
       "print_symbol": "rotations/min",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": false,
+      "is_binary": false
     },
     "{row}": {
       "symbol": "{row}",
@@ -2262,15 +2890,17 @@
       "print_symbol": "rows",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{row}/s": {
       "symbol": "{row}/s",
       "name": "rows per second",
       "print_symbol": "rows/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{rule}": {
       "symbol": "{rule}",
@@ -2278,7 +2908,8 @@
       "print_symbol": "rules",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{sample}": {
       "symbol": "{sample}",
@@ -2286,15 +2917,17 @@
       "print_symbol": "samples",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{scan}/s": {
       "symbol": "{scan}/s",
       "name": "scans per second",
       "print_symbol": "scans/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{score}": {
       "symbol": "{score}",
@@ -2302,15 +2935,17 @@
       "print_symbol": "scores",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{search}/s": {
       "symbol": "{search}/s",
       "name": "searches per second",
       "print_symbol": "searches/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{sector}": {
       "symbol": "{sector}",
@@ -2318,15 +2953,17 @@
       "print_symbol": "sectors",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{sector}/s": {
       "symbol": "{sector}/s",
       "name": "sectors per second",
       "print_symbol": "sectors/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{segment}": {
       "symbol": "{segment}",
@@ -2334,15 +2971,17 @@
       "print_symbol": "segments",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{segment}/s": {
       "symbol": "{segment}/s",
       "name": "segments per second",
       "print_symbol": "segments/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{semaphore}": {
       "symbol": "{semaphore}",
@@ -2350,15 +2989,17 @@
       "print_symbol": "semaphores",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
-    "{sensor}": {
-      "symbol": "{sensor}",
-      "name": "sensors",
-      "print_symbol": "sensors",
+    "{sender}": {
+      "symbol": "{sender}",
+      "name": "senders",
+      "print_symbol": "senders",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{server}": {
       "symbol": "{server}",
@@ -2366,7 +3007,8 @@
       "print_symbol": "servers",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{session}": {
       "symbol": "{session}",
@@ -2374,15 +3016,17 @@
       "print_symbol": "sessions",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{session}/s": {
       "symbol": "{session}/s",
       "name": "sessions per second",
       "print_symbol": "sessions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{shard}": {
       "symbol": "{shard}",
@@ -2390,7 +3034,8 @@
       "print_symbol": "shards",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{share}": {
       "symbol": "{share}",
@@ -2398,7 +3043,8 @@
       "print_symbol": "shares",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{shutdown}": {
       "symbol": "{shutdown}",
@@ -2406,7 +3052,8 @@
       "print_symbol": "shutdowns",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{sibling}": {
       "symbol": "{sibling}",
@@ -2414,7 +3061,8 @@
       "print_symbol": "siblings",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{socket}": {
       "symbol": "{socket}",
@@ -2422,23 +3070,26 @@
       "print_symbol": "sockets",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{socket}/s": {
       "symbol": "{socket}/s",
       "name": "sockets per second",
       "print_symbol": "sockets/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{softirq}/s": {
       "symbol": "{softirq}/s",
       "name": "softirqs per second",
       "print_symbol": "softirqs/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{source}": {
       "symbol": "{source}",
@@ -2446,15 +3097,17 @@
       "print_symbol": "sources",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{split}/s": {
       "symbol": "{split}/s",
       "name": "splits per second",
       "print_symbol": "splits/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{sstable}": {
       "symbol": "{sstable}",
@@ -2462,15 +3115,17 @@
       "print_symbol": "sstables",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{stack_frame}/s": {
       "symbol": "{stack_frame}/s",
       "name": "stack_frames per second",
       "print_symbol": "stack_frames/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{star}": {
       "symbol": "{star}",
@@ -2478,7 +3133,8 @@
       "print_symbol": "stars",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{statement}": {
       "symbol": "{statement}",
@@ -2486,15 +3142,17 @@
       "print_symbol": "statements",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{statement}/s": {
       "symbol": "{statement}/s",
       "name": "statements per second",
       "print_symbol": "statements/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{status}": {
       "symbol": "{status}",
@@ -2502,7 +3160,8 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{stat}": {
       "symbol": "{stat}",
@@ -2510,7 +3169,8 @@
       "print_symbol": "stats",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{stratum}": {
       "symbol": "{stratum}",
@@ -2518,15 +3178,17 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     },
     "{stub}/s": {
       "symbol": "{stub}/s",
       "name": "stubs per second",
       "print_symbol": "stubs/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{subscription}": {
       "symbol": "{subscription}",
@@ -2534,15 +3196,17 @@
       "print_symbol": "subscriptions",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{subscription}/s": {
       "symbol": "{subscription}/s",
       "name": "subscriptions per second",
       "print_symbol": "subscriptions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{switch}": {
       "symbol": "{switch}",
@@ -2550,7 +3214,8 @@
       "print_symbol": "switches",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{sync}": {
       "symbol": "{sync}",
@@ -2558,15 +3223,17 @@
       "print_symbol": "syncs",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{syscall}/s": {
       "symbol": "{syscall}/s",
       "name": "syscalls per second",
       "print_symbol": "syscalls/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{table}": {
       "symbol": "{table}",
@@ -2574,15 +3241,17 @@
       "print_symbol": "tables",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{table}/s": {
       "symbol": "{table}/s",
       "name": "tables per second",
       "print_symbol": "tables/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{task}": {
       "symbol": "{task}",
@@ -2590,15 +3259,17 @@
       "print_symbol": "tasks",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{task}/s": {
       "symbol": "{task}/s",
       "name": "tasks per second",
       "print_symbol": "tasks/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{thread}": {
       "symbol": "{thread}",
@@ -2606,15 +3277,17 @@
       "print_symbol": "threads",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{thread}/s": {
       "symbol": "{thread}/s",
       "name": "threads per second",
       "print_symbol": "threads/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{tick}": {
       "symbol": "{tick}",
@@ -2622,15 +3295,17 @@
       "print_symbol": "ticks",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{timeout}/s": {
       "symbol": "{timeout}/s",
       "name": "timeouts per second",
       "print_symbol": "timeouts/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{token}": {
       "symbol": "{token}",
@@ -2638,15 +3313,17 @@
       "print_symbol": "tokens",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{trace}/s": {
       "symbol": "{trace}/s",
       "name": "traces per second",
       "print_symbol": "traces/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{transaction}": {
       "symbol": "{transaction}",
@@ -2654,31 +3331,35 @@
       "print_symbol": "transactions",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{transaction}/s": {
       "symbol": "{transaction}/s",
       "name": "transactions per second",
       "print_symbol": "transactions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{transition}/s": {
       "symbol": "{transition}/s",
       "name": "transitions per second",
       "print_symbol": "transitions/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{trip}/s": {
       "symbol": "{trip}/s",
       "name": "trips per second",
       "print_symbol": "trips/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{tube}": {
       "symbol": "{tube}",
@@ -2686,7 +3367,8 @@
       "print_symbol": "tubes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{unsynchronized block}": {
       "symbol": "{unsynchronized block}",
@@ -2694,15 +3376,17 @@
       "print_symbol": "unsynchronized blocks",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{update}/s": {
       "symbol": "{update}/s",
       "name": "updates per second",
       "print_symbol": "updates/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{user}": {
       "symbol": "{user}",
@@ -2710,7 +3394,8 @@
       "print_symbol": "users",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{view}": {
       "symbol": "{view}",
@@ -2718,7 +3403,8 @@
       "print_symbol": "views",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{vm}": {
       "symbol": "{vm}",
@@ -2726,7 +3412,8 @@
       "print_symbol": "vms",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{volume}": {
       "symbol": "{volume}",
@@ -2734,15 +3421,17 @@
       "print_symbol": "volumes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{waiter}/s": {
       "symbol": "{waiter}/s",
       "name": "waiters per second",
       "print_symbol": "waiters/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{watch}": {
       "symbol": "{watch}",
@@ -2750,7 +3439,8 @@
       "print_symbol": "watches",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{worker}": {
       "symbol": "{worker}",
@@ -2758,15 +3448,26 @@
       "print_symbol": "workers",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{worker}/s": {
       "symbol": "{worker}/s",
       "name": "workers per second",
       "print_symbol": "workers/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
+    },
+    "{work}": {
+      "symbol": "{work}",
+      "name": "works",
+      "print_symbol": "works",
+      "is_metric": false,
+      "is_special": false,
+      "is_additive": true,
+      "is_binary": false
     },
     "{writeset}": {
       "symbol": "{writeset}",
@@ -2774,15 +3475,17 @@
       "print_symbol": "writesets",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{writeset}/s": {
       "symbol": "{writeset}/s",
       "name": "writesets per second",
       "print_symbol": "writesets/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{write}": {
       "symbol": "{write}",
@@ -2790,15 +3493,17 @@
       "print_symbol": "writes",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{write}/s": {
       "symbol": "{write}/s",
       "name": "writes per second",
       "print_symbol": "writes/s",
-      "is_metric": true,
+      "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{xid}": {
       "symbol": "{xid}",
@@ -2806,7 +3511,8 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     },
     "{zone}": {
       "symbol": "{zone}",
@@ -2814,7 +3520,8 @@
       "print_symbol": "zones",
       "is_metric": false,
       "is_special": false,
-      "is_additive": true
+      "is_additive": true,
+      "is_binary": false
     },
     "{z}": {
       "symbol": "{z}",
@@ -2822,415 +3529,69 @@
       "print_symbol": "",
       "is_metric": false,
       "is_special": false,
-      "is_additive": false
+      "is_additive": false,
+      "is_binary": false
     }
   },
   "aliases": {
-    "% of time working": "%",
-    "Ah": "A.h",
-    "Ampere": "A",
-    "Amps": "A",
     "B": "By",
     "B/s": "By/s",
-    "Celsius": "Cel",
-    "Fahrenheit": "[degF]",
-    "GiB": "GiBy",
-    "Jobs": "{job}",
-    "Joule": "J",
-    "KB": "KiBy",
-    "KiB": "KiBy",
-    "KiB/operation": "KiBy/{operation}",
-    "KiB/s": "KiBy/s",
-    "MB": "MiBy",
-    "Mbps": "Mibit/s",
-    "MiB": "MiBy",
     "MiB/s": "MiBy/s",
-    "minutes": "min",
-    "percent": "%",
-    "RPM": "{rotation}/min",
-    "rpm": "{rotation}/min",
-    "Rotations / Minute": "{rotation}/min",
-    "Rotations/min": "{rotation}/min",
-    "Status": "{status}",
-    "Volts": "V",
-    "Watt": "W",
-    "Watts": "W",
-    "Wh": "W.h",
-    "acquisitions/s": "{acquisition}/s",
-    "actions/s": "{action}/s",
-    "active connections": "{connection}",
-    "address spaces": "{address space}",
-    "answers/s": "{answer}/s",
-    "arrays": "{array}",
-    "assemblies/s": "{assembly}/s",
-    "asserts/s": "{assert}/s",
-    "associations": "{association}",
-    "attempts": "{attempt}",
-    "attempts/s": "{attempt}/s",
-    "authentications/s": "{authentication}/s",
-    "bans/s": "{ban}/s",
-    "binds/s": "{bind}/s",
-    "block": "{block}",
-    "blocked subscriptions": "{blocked subscription}",
-    "blocks": "{block}",
-    "bool": "{boolean}",
-    "boolean": "{boolean}",
-    "buffers": "{buffer}",
     "bytes": "By",
     "bytes/s": "By/s",
-    "calls": "{call}",
-    "calls/s": "{call}/s",
-    "ccw/s": "{ccw}/s",
-    "celsius": "Cel",
-    "chains": "{chain}",
-    "changes/s": "{change}/s",
-    "channels/s": "{channel}/s",
-    "characters": "{character}",
-    "checkpoints/s": "{checkpoint}/s",
-    "checks / sec": "{check}/s",
-    "checks/s": "{check}/s",
-    "children": "{child}",
-    "chunks": "{chunk}",
+    "callbacks/s": "{callback}/s",
+    "charts": "{chart}",
     "classes": "{class}",
-    "classes/s": "{class}/s",
-    "clients": "{client}",
-    "clusters": "{cluster}",
-    "clusters/s": "{cluster}/s",
-    "code": "{code}",
-    "collections": "{collection}",
-    "columns": "{column}",
-    "commands": "{command}",
-    "commands/s": "{command}/s",
-    "commits": "{commit}",
-    "commits/s": "{commit}/s",
-    "compilations/s": "{compilation}/s",
-    "components": "{component}",
-    "connections": "{connection}",
-    "connections/s": "{connection}/s",
-    "conns": "{connection}",
-    "consumers": "{consumer}",
-    "containers": "{container}",
-    "contentions/s": "{contention}/s",
-    "context switches/s": "{context switch}/s",
+    "cmd/s": "{command}/s",
+    "connected": "{status}",
+    "connected clients": "{client}",
     "contexts": "{context}",
-    "cookies/s": "{cookie}/s",
     "count": "1",
-    "counts/s": "{count}/s",
-    "cpu time": "1",
-    "cpus": "[CPU]",
-    "ctokens": "{ctoken}",
-    "current threads": "{thread}",
-    "cursors": "{cursor}",
-    "cursors/s": "{cursor}/s",
-    "cycle count": "{cycle}",
-    "cycles": "{cycle}",
-    "cycles/s": "{cycle}/s",
-    "dBm": "dB[mW]",
-    "databases": "{database}",
-    "deadlocks/s": "{deadlock}/s",
-    "depth": "{depth}",
     "descriptors": "{descriptor}",
-    "dests": "{destination}",
     "devices": "{device}",
-    "dialogs": "{dialog}",
-    "dialogs/s": "{dialog}/s",
-    "difference": "{process}",
-    "difficulty": "{difficulty}",
-    "directories": "{directory}",
-    "discards/s": "{discard}/s",
-    "disks": "{disk}",
-    "dispatches/s": "{dispatch}/s",
-    "docs": "{doc}",
-    "documents": "{document}",
-    "documents/s": "{document}/s",
-    "domain/s": "{domain}/s",
-    "domains": "{domain}",
-    "dpcs/s": "{dpc}/s",
-    "drops/s": "{drop}/s",
-    "elections/s": "{election}/s",
-    "elements": "{element}",
-    "emails": "{email}",
-    "endpoints": "{endpoint}",
+    "dictionaries": "{dictionary}",
+    "dimensions": "{dimension}",
     "entries": "{entry}",
-    "entries/s": "{entry}/s",
-    "entropy": "{entropy}",
-    "erases": "{erase}",
-    "errors": "{error}",
     "errors/s": "{error}/s",
     "events": "{event}",
     "events/s": "{event}/s",
-    "exceptions": "{exception}",
-    "exceptions/s": "{exception}/s",
-    "exit status": "{status}",
-    "expectations/s": "{expectation}/s",
-    "expired/s": "{object}/s",
-    "failed disks": "{disk}",
-    "failed servers": "{server}",
-    "fails/s": "{fail}/s",
-    "failures": "{failure}",
-    "failures/s": "{failure}/s",
-    "faults": "{fault}",
-    "faults/s": "{page fault}/s",
-    "fd": "{fd}",
-    "fetches": "{fetch}",
-    "file descriptors": "{file descriptor}",
-    "files": "{file}",
     "files/s": "{file}/s",
-    "filesystems": "{filesystem}",
-    "filters/s": "{filter}/s",
-    "finallys/s": "{finally}/s",
-    "flag": "{flag}",
-    "flows": "{flow}",
-    "flushes": "{flush}",
-    "flushes/s": "{flush}/s",
-    "fragments": "{fragment}",
-    "frames/s": "{frame}/s",
-    "fsms": "{fsm}",
-    "gc/s": "{gc}/s",
-    "goroutines": "{goroutine}",
-    "handlers/s": "{handler}/s",
-    "handles": "{handle}",
-    "handles/s": "{handle}/s",
-    "handshakes/s": "{handshake}/s",
-    "harakiris": "{harakiri}",
     "hash tables": "{hash table}",
-    "health servers": "{server}",
-    "heartbeats": "{heartbeat}",
-    "hits/s": "{hit}/s",
-    "hmode": "{ntp mode}",
-    "hosts": "{host}",
-    "hours": "h",
-    "images": "{image}",
-    "index": "{index}",
-    "indexes": "{index}",
-    "indexes/s": "{index}/s",
-    "indices": "{indice}",
-    "inodes": "{inode}",
-    "instructions/cycle": "{instruction}/{cycle}",
-    "instructions/s": "{instruction}/s",
-    "interfaces": "{interface}",
-    "interrupts": "{interrupt}",
-    "interrupts/s": "{interrupt}/s",
-    "invokes": "{invoke}",
-    "iops": "{iop}",
-    "iops/s": "{iop}/s",
-    "ips": "{ip}",
-    "is degraded": "{boolean}",
-    "issues/s": "{issue}/s",
     "items": "{item}",
     "jobs": "{job}",
-    "jobs/s": "{job}/s",
-    "joins/s": "{join}/s",
-    "keys": "{key}",
-    "keys/s": "{key}/s",
-    "kills": "{kill}",
-    "kills/s": "{kill}/s",
-    "kilobit/s": "Kibit/s",
-    "kilobits": "Kibit",
     "kilobits/s": "Kibit/s",
-    "kilobytes": "KiBy",
-    "kilobytes/s": "KiBy/s",
-    "leaseholders": "{leaseholder}",
-    "leases": "{lease}",
-    "level": "{stratum}",
-    "listeners": "{listener}",
-    "listeners/s": "{listener}/s",
-    "lists/s": "{list}/s",
-    "load": "{load}",
-    "locks": "{lock}",
-    "locks/s": "{lock}/s",
-    "log2": "{log2}",
-    "logs/s": "{log}/s",
-    "lookups/s": "{lookup}/s",
-    "mac addresses/s": "{mac address}/s",
-    "marshallings/s": "{marshalling}/s",
-    "merged operations/s": "{operation}/s",
-    "message batches": "{batch}",
-    "message batches/s": "{batch}/s",
-    "messages": "{message}",
-    "messages/s": "{message}/s",
     "methods": "{method}",
-    "methods/s": "{method}/s",
+    "metrics": "{metric}",
     "microseconds": "us",
-    "microseconds lost/s": "us/s",
-    "microseconds/s": "us/s",
-    "migrations": "{migration}",
-    "milisecondds": "ms",
-    "miliseconds": "ms",
-    "millicpu": "m[CPU]",
     "milliseconds": "ms",
-    "milliseconds/operation": "ms/{operation}",
+    "milliseconds/request": "ms/{request}",
+    "milliseconds/run": "ms/{run}",
     "milliseconds/s": "ms/s",
-    "misses": "{thread}",
-    "misses/s": "{miss}/s",
-    "modifications/s": "{modification}/s",
-    "netsplits": "{netsplit}",
-    "netsplits/s": "{netsplit}/s",
-    "nodes": "{node}",
-    "nuked/s": "{object}/s",
-    "num": "1",
-    "number": "{thread}",
-    "number/s": "{lookup}/s",
-    "objects": "{object}",
-    "objects/s": "{object}/s",
-    "observations": "{observation}",
-    "observes/s": "{observe}/s",
-    "octets": "{octet}",
-    "open files": "{file}",
-    "open pipes": "{pipe}",
-    "open sockets": "{open socket}",
-    "operations": "{operation}",
+    "models": "{model}",
+    "msg/s": "{message}/s",
+    "opcodes": "{opcode}",
     "operations/s": "{operation}/s",
     "ops/s": "{operation}/s",
-    "overflows/s": "{overflow}/s",
-    "packets": "{packet}",
     "packets/s": "{packet}/s",
-    "page faults/s": "{page fault}/s",
-    "page/s": "{page}/s",
     "pages": "{page}",
     "pages/s": "{page}/s",
-    "panics/s": "{panic}/s",
-    "peers": "{peer}",
     "percentage": "%",
-    "pgfaults/s": "{page fault}/s",
-    "pipes": "{pipe}",
-    "pmode": "{ntp mode}",
-    "pods": "{pod}",
-    "pools": "{pool}",
-    "ppm": "[ppm]",
-    "pps": "{packet}/s",
-    "prefetches": "{prefetch}",
-    "prefetches/s": "{prefetch}/s",
-    "probability": "{probability}",
-    "problems/s": "{problem}/s",
-    "processes": "{process}",
-    "processes/s": "{process}/s",
-    "producers": "{producer}",
-    "programs": "{program}",
-    "properties/s": "{propertie}/s",
-    "publishes/s": "{publish}/s",
-    "pulls": "{pull}",
-    "pulls/s": "{pull}/s",
+    "points/s": "{point}/s",
     "queries": "{query}",
     "queries/s": "{query}/s",
-    "questions/s": "{question}/s",
-    "queue processes": "{queue processe}",
-    "queue processes/s": "{queue processe}/s",
-    "queue_length": "1",
-    "queued_size": "1",
-    "queues": "{queue}",
-    "ranges": "{range}",
-    "ratio": "1",
-    "reads/query": "{read}/{query}",
     "reads/s": "{read}/s",
-    "recompiles/s": "{recompile}/s",
-    "records/s": "{record}/s",
-    "redirects/s": "{redirect}/s",
-    "reductions": "{reduction}",
-    "referrals/s": "{referral}/s",
-    "registrations/s": "{registration}/s",
-    "rejections/s": "{rejection}/s",
-    "relations": "{relation}",
-    "reorgs": "{reorg}",
-    "repairs": "{repair}",
-    "replicas": "{replica}",
-    "replies": "{reply}",
-    "replies/s": "{reply}/s",
-    "reports/s": "{report}/s",
+    "references": "{reference}",
+    "req/s": "{request}/s",
     "requests": "{request}",
     "requests/s": "{request}/s",
     "resets/s": "{reset}/s",
-    "resolutions/s": "{resolution}/s",
-    "respawns": "{respawn}",
-    "responses": "{response}",
-    "responses/s": "{response}/s",
-    "restarts": "{restart}",
-    "retries": "{retry}",
-    "retries/s": "{retry}/s",
-    "retrievals/s": "{retrieval}/s",
-    "reuses/s": "{reuse}/s",
-    "rows": "{row}",
     "rows/s": "{row}/s",
-    "rules": "{rule}",
-    "running_containers": "{container}",
-    "running_pods": "{pod}",
-    "samples": "{sample}",
-    "scans/s": "{scan}/s",
-    "score": "{score}",
-    "searches/s": "{search}/s",
     "seconds": "s",
-    "seconds/s": "s/s",
-    "sectors": "{sector}",
-    "sectors/s": "{sector}/s",
-    "segments": "{segment}",
-    "segments/s": "{segment}/s",
-    "semaphores": "{semaphore}",
-    "sensors": "{sensor}",
-    "servers": "{server}",
-    "sessions": "{session}",
-    "sessions/s": "{session}/s",
-    "shards": "{shard}",
-    "shares": "{share}",
-    "shutdowns": "{shutdown}",
-    "siblings": "{sibling}",
-    "size": "By",
+    "senders": "{sender}",
     "sockets": "{socket}",
-    "sockets/s": "{socket}/s",
-    "softirqs/s": "{softirq}/s",
-    "sources": "{source}",
-    "splits/s": "{split}/s",
-    "sstables": "{sstable}",
-    "stack_frames/s": "{stack_frame}/s",
-    "stars": "{star}",
-    "state": "{status}",
-    "statements": "{statement}",
-    "statements/s": "{statement}/s",
-    "stats": "{stat}",
-    "status": "{status}",
-    "stratum": "{stratum}",
-    "stubs/s": "{stub}/s",
-    "subscriptions": "{subscription}",
-    "subscriptions/s": "{subscription}/s",
-    "switches": "{switch}",
-    "syncs": "{sync}",
-    "syscalls/s": "{syscall}/s",
-    "tables": "{table}",
-    "tables/s": "{table}/s",
-    "tasks": "{task}",
-    "tasks/s": "{task}/s",
-    "temperature": "Cel",
     "threads": "{thread}",
-    "threads/s": "{thread}/s",
-    "ticks": "{tick}",
-    "timeout/s": "{timeout}/s",
-    "timeouts/s": "{timeout}/s",
-    "token_requests/s": "{request}/s",
-    "tokens": "{token}",
-    "total": "1",
-    "traces / sec": "{trace}/s",
-    "transactions": "{transaction}",
-    "transactions/s": "{transaction}/s",
-    "transitions/s": "{transition}/s",
-    "trips/s": "{trip}/s",
-    "tubes": "{tube}",
-    "unsynchronized blocks": "{unsynchronized block}",
-    "updates/s": "{update}/s",
-    "users": "{user}",
-    "value": "1",
-    "views": "{view}",
-    "vms": "{vm}",
-    "volumes": "{volume}",
-    "waiters/s": "{waiter}/s",
-    "watches": "{watch}",
-    "weight": "1",
+    "usec/s": "us/s",
     "workers": "{worker}",
-    "workers/s": "{worker}/s",
-    "writes": "{write}",
-    "writes/s": "{write}/s",
-    "writesets": "{writeset}",
-    "writesets/s": "{writeset}/s",
-    "xid": "{xid}",
-    "z": "{z}",
-    "zones": "{zone}"
+    "works": "{work}"
   }
 }

--- a/src/units.json
+++ b/src/units.json
@@ -439,7 +439,7 @@
       "is_metric": true,
       "is_special": false,
       "is_additive": true,
-      "is_binary": true
+      "is_binary": false
     },
     "[degF]": {
       "symbol": "[degF]",
@@ -484,7 +484,7 @@
       "is_metric": true,
       "is_special": false,
       "is_additive": true,
-      "is_binary": true,
+      "is_binary": false,
       "bare_symbol": "[CPU]",
       "prefix_symbol": "c"
     },
@@ -515,7 +515,7 @@
       "is_metric": true,
       "is_special": false,
       "is_additive": true,
-      "is_binary": true,
+      "is_binary": false,
       "bare_symbol": "[CPU]",
       "prefix_symbol": "m"
     },


### PR DESCRIPTION
This PR updates `src/units.json` to include a list of possible SI and binary prefixes, and extracts prefixes from units that include them, as per netdata/ucum#2, and then uses that to properly convert "old" units in collectors to the UCUM ones.
