### PR TITLE
Remove defaultProps syntax from functional components

### DIFF
--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -18,8 +18,10 @@ const DefaultContent = ({ children, ...rest }) => (
   </Flex>
 )
 
-const Tooltip = forwardRef(({ content, Content = DefaultContent, ...rest }, ref) =>
-  content ? (
+const Tooltip = forwardRef((props, ref) => {
+  const { content, Content = DefaultContent, ...rest } = { align: "bottom", ...props }
+
+  return content ? (
     <BaseTooltip
       ref={ref}
       plain
@@ -30,11 +32,7 @@ const Tooltip = forwardRef(({ content, Content = DefaultContent, ...rest }, ref)
   ) : (
     rest.children
   )
-)
-
-Tooltip.defaultProps = {
-  align: "bottom",
-}
+})
 
 export const withTooltip = (Component, tooltipDefaultProps = {}) =>
   forwardRef(({ title, ...rest }, ref) => {


### PR DESCRIPTION
React is going to deprecate `defaultProps` from functional components in future (throws warning on console now)
https://github.com/facebook/react/pull/16210