### PR TITLE
feat: add copy-to-clipboard functionality to chart context

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-transform-runtime": "^7.27.1",
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-react": "^7.27.1",
-    "@netdata/netdata-ui": "^5.0.10",
+    "@netdata/netdata-ui": "^5.0.22",
     "@storybook/addon-essentials": "^8.6.12",
     "@storybook/addon-interactions": "^8.6.12",
     "@storybook/addon-links": "^8.6.12",

--- a/src/components/provider/selectors.js
+++ b/src/components/provider/selectors.js
@@ -153,7 +153,7 @@ export const useName = () => {
   const name = useAttributeValue("name")
   const contextScope = useAttributeValue("contextScope")
 
-  return name || contextScope.join(", ")
+  return name || (contextScope && contextScope.length ? contextScope.join(", ") : "")
 }
 
 export const useVisibleDimensionId = id => {

--- a/src/components/title/index.js
+++ b/src/components/title/index.js
@@ -1,11 +1,12 @@
 import React from "react"
-import { Flex, TextSmall } from "@netdata/netdata-ui"
+import { Flex, TextSmall, CopyToClipboard } from "@netdata/netdata-ui"
 import {
   useTitle,
   useUnitSign,
   useName,
   withChartProvider,
   useIsMinimal,
+  useAttributeValue,
 } from "@/components/provider"
 
 export const Title = props => {
@@ -13,6 +14,7 @@ export const Title = props => {
   const units = useUnitSign({ long: true })
   const name = useName()
   const isMinimal = useIsMinimal()
+  const contextScope = useAttributeValue("contextScope")
 
   return (
     <Flex
@@ -27,10 +29,14 @@ export const Title = props => {
         {title}
       </TextSmall>
       {!!name && (!isMinimal || !title) && (
-        <TextSmall color="textLite" whiteSpace="nowrap">
-          {title ? "• " : ""}
-          {name}
-        </TextSmall>
+        <CopyToClipboard
+          text={contextScope && contextScope.length ? contextScope.join(", ") : name}
+        >
+          <TextSmall color="textLite" whiteSpace="nowrap">
+            {title ? "• " : ""}
+            {name}
+          </TextSmall>
+        </CopyToClipboard>
       )}
       {!!units && !isMinimal && (
         <TextSmall color="textLite" whiteSpace="nowrap">

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -14,7 +14,10 @@ const getChart = makeMockPayload(systemLoadLine[0], { delay: 600 })
 
 export const Simple = () => {
   const sdk = makeDefaultSDK()
-  const chart = sdk.makeChart({ getChart })
+  const chart = sdk.makeChart({ 
+    getChart,
+    attributes: { contextScope: ["system.load"] }
+  })
   sdk.appendChild(chart)
 
   return (
@@ -66,6 +69,7 @@ export const NoData = () => {
   const sdk = makeDefaultSDK()
   const chart = sdk.makeChart({
     getChart: () => new Promise(r => setTimeout(() => r(noData), 600)),
+    attributes: { contextScope: ["system.load"] }
   })
   sdk.appendChild(chart)
 
@@ -153,7 +157,7 @@ const TimePicker = withChartProvider(() => {
 export const Timepicker = () => {
   const chart = useMemo(() => {
     const sdk = makeDefaultSDK()
-    const chart = sdk.makeChart({ getChart, attributes: {} })
+    const chart = sdk.makeChart({ getChart, attributes: { contextScope: ["system.load"] } })
     sdk.appendChild(chart)
 
     return chart
@@ -174,6 +178,7 @@ export const SelectedDimensions = () => {
   const chart = sdk.makeChart({
     getChart,
     attributes: {
+      contextScope: ["system.load"],
       selectedDimensions: ["load5", "load15"],
     },
   })
@@ -245,6 +250,9 @@ export const Timeout = () => {
         return new Promise(r => setTimeout(() => getChart(params).then(r), 15000))
       return getChart(params)
     },
+    attributes: {
+      contextScope: ["system.load"]
+    }
   })
   sdk.appendChild(chart)
 
@@ -264,6 +272,9 @@ export const Error = () => {
         return new Promise((resolve, reject) => setTimeout(() => reject(), 200))
       return getChart(params)
     },
+    attributes: {
+      contextScope: ["system.load"]
+    }
   })
   sdk.appendChild(chart)
 
@@ -276,7 +287,10 @@ export const Error = () => {
 
 export const InitialLoading = () => {
   const sdk = makeDefaultSDK()
-  const chart = sdk.makeChart({ getChart: () => new Promise(() => {}) })
+  const chart = sdk.makeChart({ 
+    getChart: () => new Promise(() => {}),
+    attributes: { contextScope: ["system.load"] }
+  })
   const darkChart = sdk.makeChart({
     getChart: () => new Promise(() => {}),
     attributes: { contextScope: ["system.load"], theme: "dark" },
@@ -303,7 +317,7 @@ export const Multiple = () => {
 
   const charts = Array.from(Array(10)).map((v, index) => {
     const chart = sdk.makeChart({
-      attributes: { contextScope: ["system.load"], id: index },
+      attributes: { contextScope: ["system.load"], id: `chart-${index}` },
       getChart,
     })
     sdk.appendChild(chart)
@@ -327,7 +341,7 @@ export const Sync = () => {
 
   const charts = Array.from(Array(3)).map((v, index) => {
     const chart = sdk.makeChart({
-      attributes: { contextScope: ["system.load"], id: index, syncHover: index !== 1 },
+      attributes: { contextScope: ["system.load"], id: `chart-${index}`, syncHover: index !== 1 },
       getChart,
     })
     sdk.appendChild(chart)
@@ -351,6 +365,7 @@ export const WithAnnotations = () => {
   const chart = sdk.makeChart({
     getChart,
     attributes: {
+      contextScope: ["system.load"],
       hasCorrelation: true, // Enable correlation buttons
       overlays: {
         annotation1: {
@@ -398,6 +413,7 @@ export const AnnotationCreation = () => {
   const chart = sdk.makeChart({
     getChart,
     attributes: {
+      contextScope: ["system.load"],
       hasCorrelation: true,
     },
   })

--- a/src/sdk/makeChart/makeDimensions.js
+++ b/src/sdk/makeChart/makeDimensions.js
@@ -231,7 +231,8 @@ export default (chart, sdk) => {
     if (memKey) return memKey
     const { colors, contextScope, id } = chart.getAttributes()
 
-    memKey = colors.length ? chart.getAttribute("id") : (id || contextScope[0]).split(/[._]/)[0]
+    const keySource = String(id || (contextScope && contextScope[0]) || "default")
+    memKey = colors.length ? chart.getAttribute("id") : keySource.split(/[._]/)[0]
     return memKey
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,10 +2778,10 @@
     zod "^3.23.8"
     zod-to-json-schema "^3.24.1"
 
-"@netdata/netdata-ui@^5.0.10":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@netdata/netdata-ui/-/netdata-ui-5.0.10.tgz#8a0c39c13c8aaa65a007feea218b7d7a31b6b107"
-  integrity sha512-0ITsh49XUcg51N/Ie2XcGrzocYSin7UK2QR6cqbRFoi6EI5qqhNz682Y04KEbQbf8V6666V4Eq5Uq662qJaYHA==
+"@netdata/netdata-ui@^5.0.22":
+  version "5.0.22"
+  resolved "https://registry.yarnpkg.com/@netdata/netdata-ui/-/netdata-ui-5.0.22.tgz#0be8addb2394423e7ab815d3ab96fd2b59842f0f"
+  integrity sha512-MjteU6HcmvqPcVbg30tEAIcrBf0kcHjARpWFPPV4Vb5D0KV8oVUK3Tq1patUAwunCmgnIgChfi5LI+N+dGHyMg==
   dependencies:
     "@dnd-kit/core" "^6.3.1"
     "@dnd-kit/sortable" "^10.0.0"


### PR DESCRIPTION
## Description

This PR adds copy-to-clipboard functionality to chart context text, allowing users to click on the context to copy it with visual feedback.

## Changes

- ✨ Wrap chart context in CopyToClipboard component from netdata-ui
- 🛡️ Add validation for undefined contextScope arrays  
- 🔧 Fix type conversion for non-string chart IDs
- 🎯 Handle edge cases where context data might be missing

## Implementation Details

1. **Title Component**: Wraps context text with CopyToClipboard component
2. **Selectors**: Added validation in `useName` hook to handle undefined contextScope
3. **makeDimensions**: Convert IDs to strings to prevent `.split()` errors on non-string values

## Dependencies

This PR depends on the CopyToClipboard component from netdata-ui:
- **Required PR**: https://github.com/netdata/netdata-ui/pull/557

## Testing

- All chart contexts are now clickable
- Visual feedback appears at mouse cursor position
- Handles edge cases gracefully (undefined context, numeric IDs)

## Related Issues

Fixes issues where:
- Some Storybook examples were missing context display
- Numeric IDs caused runtime errors
- Undefined contextScope caused crashes

🤖 Generated with [Claude Code](https://claude.ai/code)