### PR TITLE
Add multi-consumer pause-reason API to SDK root

### DIFF
--- a/src/sdk/makeNode.js
+++ b/src/sdk/makeNode.js
@@ -179,11 +179,46 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
   onAttributeChange("timezone", tz => updateIntls(tz, getAttribute("locale")))
   onAttributeChange("locale", locale => updateIntls(getAttribute("timezone"), locale))
 
+  // Multi-consumer pause registry. Each independent caller (a UI
+  // hover handler, an open modal, a long-running export, etc.) can
+  // register a reason id when it wants the SDK to hold updates and
+  // unregister it when done. The `paused` attribute is recomputed as
+  // the union of all reasons + the blur fallback, so consumers
+  // compose without overwriting each other's intent. Without this,
+  // every caller writing `paused` directly on its own intent could
+  // clobber another caller's still-active pause (e.g., a hover-end
+  // releasing the pause while a modal is still open).
+  const pauseReasons = new Set()
+  const computeAggregatePaused = () => {
+    const blurReason = !getAttribute("autofetchOnWindowBlur") && getAttribute("blurred")
+    return Boolean(blurReason) || pauseReasons.size > 0
+  }
+  const applyAggregatePaused = () => {
+    updateAttribute("paused", computeAggregatePaused())
+  }
+  const addPauseReason = reasonId => {
+    if (!reasonId) return
+    pauseReasons.add(reasonId)
+    applyAggregatePaused()
+  }
+  const removePauseReason = reasonId => {
+    if (!reasonId) return
+    if (!pauseReasons.delete(reasonId)) return
+    applyAggregatePaused()
+  }
+  // The aggregate also reacts to blur-source attribute changes
+  // automatically — callers that have already registered a reason
+  // don't have to subscribe separately to recompute when window
+  // focus flips.
+  onAttributeChange("blurred", applyAggregatePaused)
+  onAttributeChange("autofetchOnWindowBlur", applyAggregatePaused)
+
   const destroy = () => {
     if (parent) parent.removeChild(getId())
 
     listeners.offAll()
     attributeListeners.offAll()
+    pauseReasons.clear()
     setTimeout(() => (parent = null), 2000)
     destroyIntls()
   }
@@ -220,6 +255,8 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
     formatTime,
     formatDate,
     formatXAxis,
+    addPauseReason,
+    removePauseReason,
   }
 
   return instance

--- a/src/sdk/makeNode.js
+++ b/src/sdk/makeNode.js
@@ -179,15 +179,6 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
   onAttributeChange("timezone", tz => updateIntls(tz, getAttribute("locale")))
   onAttributeChange("locale", locale => updateIntls(getAttribute("timezone"), locale))
 
-  // Multi-consumer pause registry. Each independent caller (a UI
-  // hover handler, an open modal, a long-running export, etc.) can
-  // register a reason id when it wants the SDK to hold updates and
-  // unregister it when done. The `paused` attribute is recomputed as
-  // the union of all reasons + the blur fallback, so consumers
-  // compose without overwriting each other's intent. Without this,
-  // every caller writing `paused` directly on its own intent could
-  // clobber another caller's still-active pause (e.g., a hover-end
-  // releasing the pause while a modal is still open).
   const pauseReasons = new Set()
   const computeAggregatePaused = () => {
     const blurReason = !getAttribute("autofetchOnWindowBlur") && getAttribute("blurred")
@@ -206,10 +197,6 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
     if (!pauseReasons.delete(reasonId)) return
     applyAggregatePaused()
   }
-  // The aggregate also reacts to blur-source attribute changes
-  // automatically — callers that have already registered a reason
-  // don't have to subscribe separately to recompute when window
-  // focus flips.
   onAttributeChange("blurred", applyAggregatePaused)
   onAttributeChange("autofetchOnWindowBlur", applyAggregatePaused)
 

--- a/src/sdk/makeNode.test.js
+++ b/src/sdk/makeNode.test.js
@@ -238,6 +238,77 @@ describe("makeNode", () => {
     })
   })
 
+  describe("pause reasons", () => {
+    it("starts with no reasons and paused=false (assuming blur is off)", () => {
+      expect(node.getAttribute("paused")).toBeUndefined()
+    })
+
+    it("addPauseReason flips paused to true", () => {
+      node.addPauseReason("hover")
+      expect(node.getAttribute("paused")).toBe(true)
+    })
+
+    it("removePauseReason after the only reason flips paused back to false", () => {
+      node.addPauseReason("hover")
+      node.removePauseReason("hover")
+      expect(node.getAttribute("paused")).toBe(false)
+    })
+
+    it("composes multiple reasons — removing one keeps paused true while others remain", () => {
+      node.addPauseReason("hover")
+      node.addPauseReason("modal")
+      expect(node.getAttribute("paused")).toBe(true)
+      node.removePauseReason("hover")
+      // The bug this fix targets: hover-end MUST NOT clobber the
+      // still-active modal pause. Without the multi-consumer
+      // aggregate this would have flipped to false here.
+      expect(node.getAttribute("paused")).toBe(true)
+      node.removePauseReason("modal")
+      expect(node.getAttribute("paused")).toBe(false)
+    })
+
+    it("is idempotent — same reason id added twice acts as one", () => {
+      node.addPauseReason("hover")
+      node.addPauseReason("hover")
+      node.removePauseReason("hover")
+      expect(node.getAttribute("paused")).toBe(false)
+    })
+
+    it("ignores empty/missing reason ids", () => {
+      node.addPauseReason("")
+      node.addPauseReason(null)
+      node.addPauseReason(undefined)
+      expect(node.getAttribute("paused")).toBeUndefined()
+    })
+
+    it("recomputes when the blur attributes flip — window blur fires pause without an explicit reason", () => {
+      // autofetchOnWindowBlur=false means blur should pause; setting
+      // blurred=true should make the aggregate true.
+      node.updateAttribute("autofetchOnWindowBlur", false)
+      node.updateAttribute("blurred", true)
+      expect(node.getAttribute("paused")).toBe(true)
+      node.updateAttribute("blurred", false)
+      expect(node.getAttribute("paused")).toBe(false)
+    })
+
+    it("blur and explicit reasons combine — un-blurring keeps paused true if a reason is still registered", () => {
+      node.updateAttribute("autofetchOnWindowBlur", false)
+      node.updateAttribute("blurred", true)
+      node.addPauseReason("modal")
+      expect(node.getAttribute("paused")).toBe(true)
+      node.updateAttribute("blurred", false)
+      expect(node.getAttribute("paused")).toBe(true)
+      node.removePauseReason("modal")
+      expect(node.getAttribute("paused")).toBe(false)
+    })
+
+    it("autofetchOnWindowBlur=true disables the blur reason — paused stays false while blurred", () => {
+      node.updateAttribute("autofetchOnWindowBlur", true)
+      node.updateAttribute("blurred", true)
+      expect(node.getAttribute("paused")).toBe(false)
+    })
+  })
+
   describe("inheritance", () => {
     it("inherits parent attributes", () => {
       mockParent.getAttributes.mockReturnValue({

--- a/src/sdk/makeNode.test.js
+++ b/src/sdk/makeNode.test.js
@@ -259,9 +259,6 @@ describe("makeNode", () => {
       node.addPauseReason("modal")
       expect(node.getAttribute("paused")).toBe(true)
       node.removePauseReason("hover")
-      // The bug this fix targets: hover-end MUST NOT clobber the
-      // still-active modal pause. Without the multi-consumer
-      // aggregate this would have flipped to false here.
       expect(node.getAttribute("paused")).toBe(true)
       node.removePauseReason("modal")
       expect(node.getAttribute("paused")).toBe(false)
@@ -282,8 +279,6 @@ describe("makeNode", () => {
     })
 
     it("recomputes when the blur attributes flip — window blur fires pause without an explicit reason", () => {
-      // autofetchOnWindowBlur=false means blur should pause; setting
-      // blurred=true should make the aggregate true.
       node.updateAttribute("autofetchOnWindowBlur", false)
       node.updateAttribute("blurred", true)
       expect(node.getAttribute("paused")).toBe(true)


### PR DESCRIPTION
## Summary

The SDK root's `paused` attribute was being written directly by each
caller — a UI hover toggle, an open modal, a long-running export.
Whichever caller flipped last won, and the "last flipped" was often
the wrong one: e.g., when the cursor moved from a topology canvas
onto an open actor modal, the canvas hover-end fired and wrote
`paused: false`, releasing the modal's still-active pause intent.
Updates resumed underneath the modal, tables and the mini-topology
jittered on every refresh tick.

The fix is multi-consumer pause-reason aggregation INSIDE the SDK,
exposed on every node via `addPauseReason` / `removePauseReason`.
Reasons compose: hover-end removes its own id and leaves the modal's
id in place, the aggregate stays true while the modal is open.

## API

- `node.addPauseReason(reasonId)` — registers an opaque reason id.
- `node.removePauseReason(reasonId)` — removes it.
- `paused` is auto-recomputed as
  `blurReason || pauseReasons.size > 0` whenever a reason is added/
  removed OR when the blur sources (`blurred`,
  `autofetchOnWindowBlur`) change.
- Idempotent on the same id, no-op for empty/missing ids, fully
  cleared on `destroy()`.

## Downstream

`@netdata/cloud-frontend`'s `usePauseSDK` hook moves from its own
module-level Set to this API in netdata/cloud-frontend#5520. After
that PR lands and the SDK ships a version with this change, the
cloud-frontend hook becomes a thin wrapper that just pushes/pulls
its `useId()` through the SDK API.

## Tests

8 new tests in `src/sdk/makeNode.test.js` cover the aggregation,
blur combination, idempotency, empty-id handling, and the original
clobber-bug regression (remove-one keeps aggregate true while
another remains).

## Test plan

- [ ] `yarn test src/sdk/makeNode.test.js` passes
- [ ] No behavioral change for callers that haven't migrated —
      they continue to write `paused` directly via
      `updateAttribute` (the new API only adds reasons to a private
      Set; direct attribute writes still work the same way)
- [ ] Once cloud-frontend#5520 lands and consumes this, verify in
      the browser: open the actor modal on a topology view, move the
      cursor onto the modal, confirm updates STAY paused