### PR TITLE
Fix heatmap bucket ordering and popovers

### DIFF
--- a/docs/sow-heatmap-axis-ordering.md
+++ b/docs/sow-heatmap-axis-ordering.md
@@ -636,6 +636,142 @@ can collapse into a single remaining bucket.
 - Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
   existing errors outside this change.
 
+## Follow-up Scope: Heatmap Popover Axis Order
+
+### User-approved requirement
+
+Heatmap popovers must not be value sorted. Value sorting is misleading for
+bucketed heatmaps because the popover order stops matching the bucket scale.
+Heatmap popovers must use the same bucket ordering and label formatting model
+as the heatmap y-axis, including the 5 + 1 + 1 zero-edge crop. Cropping is
+necessary because bucket counts can be large and the popover must stay readable.
+
+Non-heatmap popovers must not be affected.
+
+### Evidence
+
+- The generic line popover requests `valueDesc` for normal value rows.
+- Heatmaps need bucket-scale ordering, not value ranking, because each row is a
+  bucket boundary on the y-axis scale.
+- `chart.getVisibleHeatmapIds()` applies `cropHeatmapZeroEdges()` and is the
+  list already used by the rendered heatmap y-axis.
+- The base heatmap id list can be too large for popovers when many buckets are
+  present.
+- Heatmap label formatting is already centralized through
+  `chart.getDimensionName()` after the prior label-formatting change.
+
+### Requirements
+
+- Heatmap popovers must ignore requested value/anomaly/annotation sort methods.
+- Heatmap popovers must return cropped heatmap bucket order:
+  numeric bucket order when available, otherwise normal visible dimension order,
+  after applying the 5 + 1 + 1 zero-edge crop.
+- Heatmap labels must remain scaled exactly like y-axis labels.
+- Non-heatmap `onHoverSortDimensions()` behavior must remain unchanged.
+
+### Implementation
+
+- `src/sdk/makeChart/makeDimensions.js` now returns
+  `chart.getVisibleHeatmapIds()` directly for heatmap hover popovers.
+- This means heatmap popovers ignore the generic line-popover `valueDesc`
+  request and stay in bucket-scale order.
+- Because `chart.getVisibleHeatmapIds()` is the cropped heatmap list, heatmap
+  popovers stay decluttered when the source has many buckets.
+- Non-heatmap popovers still call the existing requested sort method with
+  `chart.getVisibleDimensionIds()`.
+- Scaled heatmap label formatting remains in `chart.getDimensionName()`.
+
+### Verification
+
+- Updated regression tests proving:
+  - heatmap popovers ignore `valueDesc`;
+  - heatmap popovers use cropped y-axis bucket order;
+  - non-heatmap popovers remain value-sorted.
+- Passed focused makeDimensions tests:
+  `yarn test src/sdk/makeChart/makeDimensions.test.js --coverage=false --runInBand`
+- Passed broader heatmap/chart tests:
+  `yarn test src/sdk/makeChart/makeDimensions.test.js src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js src/chartLibraries/dygraph/index.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed scoped lint on changed source/test files:
+  `./node_modules/.bin/eslint src/sdk/makeChart/makeDimensions.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/hoverX.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.js src/chartLibraries/dygraph/plotters/heatmap.test.js`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend rebuild and install:
+  `sudo ./agent.sh`
+- Passed cloud-frontend final install copy:
+  `sudo ./agent.sh install`
+- Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
+  existing errors outside this change.
+
+## Follow-up Scope: Heatmap Popover List Windowing
+
+### User-approved requirement
+
+Heatmap popovers must keep the heatmap bucket crop, because bucket counts can be
+large and zero-only scale edges should be removed. After that heatmap-specific
+crop is applied, the popover must show all remaining heatmap buckets. It must
+not apply the generic popover window that hides rows behind `+N more values`.
+
+Non-heatmap popovers must keep the existing generic popover windowing behavior.
+
+### Evidence
+
+- `chart.getVisibleHeatmapIds()` already returns the heatmap-specific cropped
+  bucket list.
+- `src/components/line/popover/dimensions.js` then applies a second generic
+  row window with `getFrom()`, `getTo()`, and `dimensionIds.slice(from, to)`.
+- That generic window is what renders `↑N more values` and `↓N more values`.
+- Applying both crops to heatmaps hides buckets that already survived the
+  heatmap-specific crop.
+
+### Requirements
+
+- Heatmap popovers must still get ids through `chart.onHoverSortDimensions()`,
+  which returns the cropped heatmap bucket list.
+- Heatmap popovers must render that returned list in full.
+- Heatmap popovers must not render `more values` indicators.
+- Non-heatmap popovers must still apply the generic row window and `more values`
+  indicators.
+
+### Implementation
+
+- `src/components/line/popover/dimensions.js` now detects heatmap charts before
+  applying the generic popover row window.
+- For heatmaps, the popover renders the full id list returned by
+  `chart.onHoverSortDimensions()`. That list is already the cropped heatmap
+  bucket list.
+- For non-heatmaps, the existing `getFrom()`, `getTo()`, `slice()`, and
+  `more values` behavior is unchanged.
+
+### Verification
+
+- Added rendered popover regression tests proving:
+  - heatmaps render all buckets that survived the heatmap bucket crop;
+  - heatmaps do not render `more values` indicators;
+  - non-heatmap popovers still render the generic `more values` indicator when
+    there are more than 10 dimensions.
+- Passed focused popover tests:
+  `yarn test src/components/line/popover/dimensions.test.js --coverage=false --runInBand`
+- Passed broader heatmap/chart/popover tests:
+  `yarn test src/components/line/popover/dimensions.test.js src/sdk/makeChart/makeDimensions.test.js src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js src/chartLibraries/dygraph/index.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed scoped lint on changed source/test files:
+  `./node_modules/.bin/eslint src/components/line/popover/dimensions.js src/components/line/popover/dimensions.test.js src/sdk/makeChart/makeDimensions.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/hoverX.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.js src/chartLibraries/dygraph/plotters/heatmap.test.js`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend rebuild and install:
+  `sudo ./agent.sh`
+- Passed cloud-frontend final install copy:
+  `sudo ./agent.sh install`
+- Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
+  existing errors outside this change.
+
 ## Follow-up Scope: Heatmap Edge Zero Cropping
 
 ### User-approved requirement
@@ -704,5 +840,169 @@ all dimensions remain visible.
   `yarn to-cloud`
 - Passed cloud-frontend consuming build after the copy:
   `ENV=production yarn build:dev` from `../cloud-frontend`
+- Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
+  existing errors outside this change.
+
+## Follow-up Scope: Heatmap Hover Row Alignment
+
+### User-approved requirement
+
+Heatmap hover must show the value for the cell under the hairline. The rendered
+cell color, selected timestamp row, highlighted y bucket, and popover value
+must all refer to the same payload row and bucket. The fix is surgical: do not
+change API data, Dygraph x-axis behavior, bucket ordering, or zero-edge
+cropping behavior.
+
+### Evidence
+
+- Dygraph points carry `idx`, the original payload row index. The point-array
+  loop index is only the index inside Dygraph's current visible point set.
+- Dygraph can slice points to the visible date window, making point-array index
+  and payload row index diverge.
+- The heatmap plotter painted each cell at `p.canvasx` but read the color value
+  with the loop index, so a rendered cell could be colored from the previous or
+  next payload row.
+- Hover bucket selection asked Dygraph for the closest x/y point and used only
+  the returned series name. The row returned by that nearest-point search was
+  ignored, while the hairline and popover continued to use the selected x
+  timestamp row.
+- Heatmap y geometry is custom: the plotter positions buckets with
+  `getHeatmapYIndex()`, not with Dygraph's point y-value. Therefore Dygraph's
+  generic nearest-point y search is not authoritative for heatmap bucket
+  selection.
+
+### Requirements
+
+- Heatmap rendering must read values using `point.idx` when Dygraph provides it.
+- Fallback to the loop index only when a point has no numeric `idx`, preserving
+  defensive behavior for tests or unexpected Dygraph shapes.
+- Heatmap hover must derive the y bucket from the cursor's y position and the
+  current visible heatmap bucket list.
+- Heatmap hover must keep the x timestamp supplied by Dygraph's selected row;
+  only the bucket selection logic changes.
+- Non-heatmap hover behavior must remain unchanged.
+- Add regression tests for both mismatches.
+
+### Implementation
+
+- `src/chartLibraries/dygraph/plotters/heatmap.js` now uses `p.idx` for value
+  lookup when available and falls back to the point-array loop index.
+- `src/chartLibraries/dygraph/hoverX.js` now maps heatmap cursor y to
+  `chart.getVisibleHeatmapIds()` via `dygraph.toDomYCoord(index)` bucket
+  centers, instead of using `findClosestPoint()`.
+- Non-heatmap hover paths still use the existing Dygraph nearest-point or
+  stacked-point logic.
+
+### Verification
+
+- Added failing-first regression tests proving:
+  - heatmap renderer uses `p.idx` instead of the point-array index;
+  - heatmap hover ignores a neighboring `findClosestPoint()` result and selects
+    the bucket under the cursor.
+- Passed focused regressions:
+  `yarn test src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/hoverX.test.js --coverage=false --runInBand`
+- Passed broader heatmap/chart tests:
+  `yarn test src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/index.test.js src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed scoped lint on changed source/test files:
+  `./node_modules/.bin/eslint src/chartLibraries/dygraph/hoverX.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.js src/chartLibraries/dygraph/plotters/heatmap.test.js`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend rebuild and install:
+  `sudo ./agent.sh`
+- Passed final cloud-frontend install copy:
+  `sudo ./agent.sh install`
+- Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
+  existing errors outside this change.
+
+## Superseded Follow-up Scope: Heatmap Popover Sorting and Labels
+
+This section records the earlier value-sorted heatmap popover approach. It is
+superseded by `Follow-up Scope: Heatmap Popover Axis Order` above.
+
+### Superseded requirement
+
+Heatmap popovers must be value-sorted like normal chart popovers. The heatmap
+popover labels must use the same scaled bucket formatting as the heatmap y-axis.
+Non-heatmap popovers must not be affected.
+
+### Evidence
+
+- The line popover asks for value sorting by passing `valueDesc` for normal
+  value rows.
+- `chart.onHoverSortDimensions()` overrides all heatmap popover sorting to the
+  default dimension sort, so heatmaps do not honor the requested value sort.
+- The default sort falls back to `getDimensionName(...).localeCompare(...)`,
+  which creates lexicographic ordering when priorities do not dominate.
+- Heatmap y-axis labels already use `formatHeatmapLabel(..., scale)`.
+- Popover labels use `chart.getDimensionName()`, and the heatmap branch only
+  strips prefixes. It does not apply heatmap scale formatting.
+- The rendered heatmap uses `getVisibleHeatmapIds()`, while the popover uses
+  `getVisibleDimensionIds()`. After edge cropping, this can let the popover
+  include buckets not currently visible on the heatmap.
+
+### Requirements
+
+- Heatmap popovers must sort by the requested hover sort method, especially
+  `valueDesc`.
+- Heatmap popovers must use `getVisibleHeatmapIds()` so cropped buckets do not
+  appear in the popover list.
+- Heatmap popover labels must use `formatHeatmapLabel()` with the chart's
+  detected heatmap scale.
+- Non-heatmap `onHoverSortDimensions()` behavior must remain unchanged.
+- Add regression tests for heatmap value sorting, heatmap scaled labels, cropped
+  heatmap popover ids, and non-heatmap value sorting.
+
+### Implementation Plan
+
+- Update `chart.onHoverSortDimensions()` to select the visible id source based
+  on chart type:
+  - heatmap: `chart.getVisibleHeatmapIds()`
+  - non-heatmap: `chart.getVisibleDimensionIds()`
+- Let heatmaps use the requested sort method instead of forcing default sort.
+- Update heatmap `chart.getDimensionName()` to use `formatHeatmapLabel()` after
+  prefix stripping, using `chart.getHeatmapScale()`.
+
+### Implementation
+
+- `src/sdk/makeChart/makeDimensions.js` now lets heatmaps use the requested
+  hover sort method instead of forcing the default dimension sort.
+- Heatmap hover popovers now read ids from `chart.getVisibleHeatmapIds()`, so
+  buckets cropped from the rendered heatmap are not shown in the popover.
+- Non-heatmap hover popovers still read ids from `chart.getVisibleDimensionIds()`
+  and still use the requested hover sort method.
+- Heatmap `chart.getDimensionName()` now formats bucket labels with
+  `formatHeatmapLabel(withoutPrefix(...), chart.getHeatmapScale())`, matching
+  the y-axis label formatter.
+- Legend selection compatibility for prefixed heatmap buckets is preserved by
+  matching the raw stripped bucket label as well as the displayed formatted
+  label.
+
+### Verification
+
+- Added failing-first regression tests proving:
+  - heatmap hover popovers use value sorting and cropped visible heatmap ids;
+  - heatmap popover labels use scaled formatting;
+  - raw prefixed bucket legend selection still works after label formatting;
+  - non-heatmap hover popovers remain value-sorted.
+- Passed focused makeDimensions tests:
+  `yarn test src/sdk/makeChart/makeDimensions.test.js --coverage=false --runInBand`
+- Passed broader heatmap/chart tests:
+  `yarn test src/sdk/makeChart/makeDimensions.test.js src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js src/chartLibraries/dygraph/index.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed scoped lint on changed source/test files:
+  `./node_modules/.bin/eslint src/sdk/makeChart/makeDimensions.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/hoverX.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.js src/chartLibraries/dygraph/plotters/heatmap.test.js`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend rebuild and install:
+  `sudo ./agent.sh`
+- Passed cloud-frontend final install copy:
+  `sudo ./agent.sh install`
 - Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
   existing errors outside this change.

--- a/docs/sow-heatmap-axis-ordering.md
+++ b/docs/sow-heatmap-axis-ordering.md
@@ -706,6 +706,63 @@ Non-heatmap popovers must not be affected.
 - Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
   existing errors outside this change.
 
+## Follow-up Scope: All-Zero Heatmap Color
+
+### Requirement
+
+When a heatmap's entire visible data range is zero, the heatmap must render
+zero cells with the low-end color, not the high-end highlighted color. Missing
+cells must remain transparent. Positive-max heatmaps must keep the existing
+gradient behavior.
+
+### Evidence
+
+- `makeGetColor()` builds a D3 linear scale from the chart `max`
+  (`src/helpers/heatmap.js:35-43`).
+- When `max` is `0`, the generated domain collapses to repeated zero values.
+  D3's linear scale then maps `0` to the high end of the range, making an
+  all-zero heatmap look highlighted instead of empty/dim.
+- The existing tests only asserted that zero returned some RGB color; they did
+  not assert which end of the heatmap palette zero maps to
+  (`src/helpers/heatmap.test.js:128-130`).
+
+### Design Decision
+
+Use a surgical guard in `makeGetColor()`: if the chart max is not a positive
+finite number, return the first palette color for real cells and keep
+`transparent` for `null`/`undefined`. This avoids a degenerate D3 scale while
+leaving all positive-max heatmaps on the existing gradient path.
+
+### Implementation
+
+- `src/helpers/heatmap.js` now converts the chart max to a number before
+  building the scale.
+- If the max is not a positive finite value, `makeGetColor()` returns the
+  first heatmap palette color for real values and keeps missing values
+  transparent.
+- Positive-max heatmaps still use the existing D3 linear color scale.
+
+### Verification
+
+- Added a failing-first regression test proving `max = 0` previously mapped
+  `value = 0` to a highlighted color instead of the low-end color.
+- Passed focused regression:
+  `yarn test src/helpers/heatmap.test.js --coverage=false --runInBand`
+- Passed broader heatmap/chart/popover tests:
+  `yarn test src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/index.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js src/chartLibraries/dygraph/hoverX.test.js src/components/line/popover/dimensions.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed scoped lint on changed files:
+  `./node_modules/.bin/eslint src/helpers/heatmap.js src/helpers/heatmap.test.js`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend final install copy:
+  `sudo ./agent.sh install`
+- Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
+  existing errors outside this change.
+
 ## Follow-up Scope: Heatmap Popover List Windowing
 
 ### User-approved requirement

--- a/docs/sow-heatmap-axis-ordering.md
+++ b/docs/sow-heatmap-axis-ordering.md
@@ -635,3 +635,74 @@ can collapse into a single remaining bucket.
   `ENV=production yarn build:dev` from `../cloud-frontend`
 - Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
   existing errors outside this change.
+
+## Follow-up Scope: Heatmap Edge Zero Cropping
+
+### User-approved requirement
+
+Heatmaps should visually crop zero-only buckets only at the bottom and top
+edges. Interior zero buckets must remain visible. The crop must keep at least
+5 buckets visible when there is any non-zero bucket. The crop must also retain
+one zero-only bucket below the non-zero span and one zero-only bucket above the
+non-zero span when such buckets exist; this gives users visual context that the
+data does not occupy the whole scale. This does not change the minimum from 5
+to 7. If all buckets are zero, the full bucket scale must remain visible so
+users can still see the scale.
+
+This aligns with the Netdata `nonzero` behavior: when all dimensions are zero,
+all dimensions remain visible.
+
+### Evidence
+
+- Heatmap bucket order already has a dedicated sorted-id path in
+  `src/sdk/makeChart/makeDimensions.js`.
+- The heatmap y-axis already asks `getVisibleHeatmapIds()` for labels in
+  `src/chartLibraries/dygraph/index.js`.
+- The heatmap plotter uses `getHeatmapYIndex()` to map each bucket id to its
+  row in `src/chartLibraries/dygraph/plotters/heatmap.js`.
+- Incremental heatmap values depend on `isDimensionVisible()` when subtracting
+  previous bucket values in `src/sdk/makeChart/makeDimensions.js`.
+
+### Requirements
+
+- Do not remove dimensions from the API response.
+- Do not alter global dimension visibility for the crop, because that can break
+  incremental heatmap bucket math.
+- Apply cropping only to the heatmap-visible id list used by y-axis labels,
+  heatmap row mapping, and heatmap value range.
+- Crop only leading and trailing zero-only buckets.
+- Preserve interior zero-only buckets.
+- Preserve the full scale when all visible buckets are zero-only.
+- Keep at least 5 buckets visible when there is any non-zero bucket.
+- Keep one zero-only bucket below and one zero-only bucket above the non-zero
+  span when those buckets exist and would otherwise be hidden.
+
+### Implementation
+
+- Added a pure `cropHeatmapZeroEdges()` helper in `src/helpers/heatmap.js`.
+- `chart.getVisibleHeatmapIds()` now crops only the heatmap-visible bucket id
+  list. It does not change global dimension visibility.
+- `chart.getHeatmapYIndex()` returns `-1` for cropped heatmap buckets so the
+  plotter skips those rows.
+- Dygraph heatmap `valueRange` now uses the cropped heatmap bucket count, so
+  the y-axis range and rendered rows stay aligned.
+- Added a shared real raw heatmap payload test helper under
+  `jest/testUtilities/heatmapPayload.js` so crop tests use `doneFetch()` and
+  the same internal payload state production uses.
+
+### Verification
+
+- Passed focused heatmap tests:
+  `yarn test src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/index.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed scoped lint on changed files:
+  `./node_modules/.bin/eslint jest/testUtilities/heatmapPayload.js jest/testUtilities/index.js src/helpers/heatmap.js src/helpers/heatmap.test.js src/sdk/makeChart/makeDimensions.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/index.js src/chartLibraries/dygraph/index.test.js`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend consuming build after the copy:
+  `ENV=production yarn build:dev` from `../cloud-frontend`
+- Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
+  existing errors outside this change.

--- a/docs/sow-heatmap-axis-ordering.md
+++ b/docs/sow-heatmap-axis-ordering.md
@@ -581,3 +581,57 @@ obvious because they render hard-edged cells across the full plot area.
   `./node_modules/.bin/eslint src/sdk/initialAttributes.js src/sdk/makeChart/api/helpers.js src/sdk/makeChart/api/helpers.test.js src/sdk/makeChart/index.js src/sdk/makeChart/index.test.js src/sdk/makeChart/makeDataFetch.js src/sdk/makeChart/makeDataFetch.test.js`
 - Repo-wide lint was also checked with `yarn lint`; it still fails on
   unrelated existing errors outside this change.
+
+## Follow-up Scope: Heatmap Nonzero API Option
+
+### User-approved requirement
+
+The `nonzero` API option must not be sent for heatmaps. The option removes
+dimensions that contain only zero values, but heatmaps depend on all bucket
+dimensions being present. When `nonzero` is applied to heatmap data, the chart
+can collapse into a single remaining bucket.
+
+### Evidence
+
+- `eliminateZeroDimensions` defaults to true
+  (`src/sdk/initialAttributes.js`).
+- `getChartURLOptions()` currently adds `nonzero` for all non-table chart
+  libraries (`src/sdk/makeChart/api/helpers.js`).
+- Heatmaps are rendered through the dygraph chart library, so the existing
+  `chartLibrary !== "table"` guard still allows `nonzero` for heatmaps.
+
+### Requirements
+
+- Keep `nonzero` for normal non-table, non-heatmap charts.
+- Keep excluding `nonzero` for table charts.
+- Exclude `nonzero` when `chartType` is `heatmap`.
+- Exclude `nonzero` when `selectedChartType` is `heatmap`, so explicit heatmap
+  state is protected before the rendered chart type catches up.
+
+### Implementation
+
+- `getChartURLOptions()` now computes an effective chart type from
+  `selectedChartType || chartType`.
+- `nonzero` is only added when zero-dimension elimination is enabled and the
+  chart is neither a table nor a heatmap.
+
+### Verification
+
+- Added failing-first tests proving `nonzero` was still present for
+  `chartType: "heatmap"` and `selectedChartType: "heatmap"`.
+- Passed helper regression tests:
+  `yarn test src/sdk/makeChart/api/helpers.test.js --coverage=false --runInBand`
+- Passed focused API and heatmap tests:
+  `yarn test src/sdk/makeChart/api src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js src/chartLibraries/dygraph/index.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed scoped lint on changed source/test files:
+  `./node_modules/.bin/eslint src/sdk/makeChart/api/helpers.js src/sdk/makeChart/api/helpers.test.js`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend consuming build after the copy:
+  `ENV=production yarn build:dev` from `../cloud-frontend`
+- Repo-wide lint was checked with `yarn lint`; it still fails on unrelated
+  existing errors outside this change.

--- a/docs/sow-heatmap-axis-ordering.md
+++ b/docs/sow-heatmap-axis-ordering.md
@@ -492,3 +492,92 @@ testing rules). Pure function input/output assertions.
 2. Prefix spacing — compact labels are chosen: `"5m"`, `"1.5k"`, `"1Mi"`.
    This is shorter and fits better in narrow y-axis space. Confirmed by user.
 3. Decimal count — up to 2 decimal places, stripping trailing zeros.
+
+## Follow-up Scope: Live Heatmap X-Axis Synchronization
+
+### User-approved decision
+
+**Decision:** A — test-first surgical fix.
+
+The user reported that in PLAY mode the x-axis and heatmap sometimes advance
+on alternating seconds:
+
+- PLAY tick advances the x-axis by one second while the heatmap stays in place.
+- Fetch completion advances the heatmap by one second while the x-axis stays in
+  place.
+- The effect can alternate on odd/even seconds or catch up within the same
+  second depending on fetch timing.
+
+### Evidence
+
+- PLAY mode updates `root.fetchAt` from `Date.now()` and triggers render once
+  per second (`src/sdk/plugins/play.js`).
+- `chart.getDateWindow()` uses `root.fetchAt` for relative live windows
+  (`src/sdk/makeChart/index.js`).
+- API payload windows use `fetchStartedAt`, rounded with
+  `Math.ceil(fetchStartedAt / 1000)` (`src/sdk/makeChart/api/helpers.js`).
+- Successful fetch processing is deferred with `setTimeout(..., 0)` before it
+  triggers render (`src/sdk/makeChart/makeDataFetch.js`).
+- Heatmap cell x positions come from payload row timestamps, copied through
+  `camelizePayload.js` and rendered by the Dygraph heatmap plotter.
+
+### Working theory
+
+The heatmap renderer itself is not asynchronous. The visible dancing is caused
+by two different live clocks:
+
+- x-axis clock: `root.fetchAt`
+- payload clock: `fetchStartedAt` rounded to seconds
+
+These clocks can diverge by about one second. Heatmaps make the mismatch
+obvious because they render hard-edged cells across the full plot area.
+
+### Requirements
+
+- Add a failing test that reproduces the one-second divergence before changing
+  implementation.
+- Apply the smallest fix that makes live relative date windows and fetched
+  payload windows use the same effective timestamp.
+- Preserve absolute windows (`after > 0`) and hover/frozen rendered windows.
+- Keep the change global only if necessary; do not add a heatmap-only timing
+  workaround unless the source-level evidence requires it.
+
+### Implementation
+
+- Added `liveAnchor` as a chart attribute. `chart.getDateWindow()` uses it for
+  live relative windows when present, instead of advancing from the root
+  `fetchAt` clock between payload updates.
+- Extracted `getLiveFetchBefore()` from the API payload helper so API payload
+  windows and chart render windows share the same live anchor calculation.
+- Bound the live anchor to the specific fetch response closure. This avoids a
+  race where a second fetch with different attributes could otherwise affect a
+  queued `doneFetch()` callback from a previous response.
+- Preserved absolute windows and `viewUpdateEvery` windows that the API keeps
+  relative (`before: 0`).
+
+### Verification
+
+- Added a regression test proving `getDateWindow()` stays anchored while
+  `root.fetchAt` advances between payload updates.
+- Added helper tests for live relative, hover-rendered, absolute, and
+  `viewUpdateEvery` request windows.
+- Added fetch lifecycle tests proving successful fetches store the same live
+  request anchor used by the API payload window.
+- Added an async race test proving queued fetch responses keep their own live
+  anchor when another fetch starts before the queued callback runs.
+- Passed focused SDK tests:
+  `yarn test src/sdk/makeChart/index.test.js src/sdk/makeChart/makeDataFetch.test.js src/sdk/makeChart/api/helpers.test.js --coverage=false --runInBand`
+- Passed focused heatmap/dygraph tests:
+  `yarn test src/helpers/heatmapScale.test.js src/sdk/makeChart/makeDimensions.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js src/chartLibraries/dygraph/index.test.js src/sdk/makeChart/index.test.js src/sdk/makeChart/makeDataFetch.test.js src/sdk/makeChart/api/helpers.test.js --coverage=false --runInBand`
+- Passed full tests:
+  `yarn test --coverage=false --runInBand`
+- Passed build:
+  `yarn build`
+- Passed package copy to cloud-frontend:
+  `yarn to-cloud`
+- Passed cloud-frontend consuming build after the copy:
+  `ENV=production yarn build:dev` from `../cloud-frontend`
+- Passed scoped lint on changed source/test files:
+  `./node_modules/.bin/eslint src/sdk/initialAttributes.js src/sdk/makeChart/api/helpers.js src/sdk/makeChart/api/helpers.test.js src/sdk/makeChart/index.js src/sdk/makeChart/index.test.js src/sdk/makeChart/makeDataFetch.js src/sdk/makeChart/makeDataFetch.test.js`
+- Repo-wide lint was also checked with `yarn lint`; it still fails on
+  unrelated existing errors outside this change.

--- a/docs/sow-heatmap-axis-ordering.md
+++ b/docs/sow-heatmap-axis-ordering.md
@@ -1,0 +1,494 @@
+# SOW: Heatmap Y-Axis Bucket Ordering and Label Scaling
+
+## Requirements (Purpose)
+
+Heatmap charts in `@netdata/charts` render histogram buckets on the y-axis. The
+current implementation trusts the dimension payload order blindly, which breaks
+when the Netdata agent appends a new bucket at runtime (e.g. user adds bucket
+`3` to `1, 2, 5, 10` → agent stores `1, 2, 5, 10, +Inf, 3` → `3` renders at the
+bottom, below `+Inf`).
+
+This SOW delivers:
+1. **Correct, robust bucket ordering** — numeric sort by bucket value,
+   `+Inf` last, with a safe fallback to payload order when values are not
+   purely numeric.
+2. **Humanized y-axis labels** — for automated dashboards where no unit
+   metadata exists for the bucket boundaries, format labels using sensible
+   defaults inferred from the bucket values themselves (binary vs SI scaling).
+
+The solution must be **fit for purpose** for Netdata's automated dashboards:
+no per-chart configuration required, sensible defaults for the common
+histogram sources (Prometheus, OpenTelemetry), and zero regressions for
+non-numeric heatmaps.
+
+## Background and Context
+
+### Current behavior (the bug)
+
+- `getDimensionIndex(id)` returns the **raw payload index**
+  (`src/sdk/makeChart/makeDimensions.js:202,229`).
+- The heatmap plotter draws row N at the payload index
+  (`src/chartLibraries/dygraph/plotters/heatmap.js:27,41`).
+- The heatmap ticker emits one tick per index
+  (`src/chartLibraries/dygraph/tickers/heatmap.js:12-14`).
+- `onHoverSortDimensions` forces `default` sort for heatmaps
+  (`src/sdk/makeChart/makeDimensions.js:164-165`), but this only affects
+  legend/visibility — the plotter ignores `sortedDimensionIds` and reads
+  `getDimensionIndex` directly.
+
+### Root cause
+
+The Netdata agent (OTel plugin) re-sorts and re-emits the chart definition
+when dimensions change
+(`netdata/src/crates/netdata-otel/otel-plugin/src/chart.rs:382-385`), but the
+agent core stores dimensions in an ordered dict and SQLite **at insertion
+position** — it does not reorder on update. A runtime-added bucket lands after
+the existing `+Inf`. The frontend faithfully renders that broken order.
+
+### Bucket value format (verified)
+
+The live Prometheus API payload for `prometheus.vllm.request_prefill_time`
+exposes `view.dimensions.ids` and `view.dimensions.names` as pure numeric
+strings or the literal `+Inf`:
+
+```
++Inf, 0.3, 0.5, 0.8, 1, 1.5, 10, 120, 15, 1920, 2, 2.5, ...
+```
+
+The Prometheus collector starts from Prometheus bucket series
+`<metric>_bucket{le="<bound>"}` (`netdata/src/go/pkg/prometheus/parse.go:292`),
+then strips `_bucket` and `le` into typed histogram bounds
+(`netdata/src/go/pkg/prometheus/assemble.go:190-205`). Netdata's metrix layer
+can flatten histograms back to `_bucket{le="<bound>"}`
+(`netdata/src/go/pkg/metrix/reader.go:249-256`), and chartengine autogen can
+use internal names like `bucket_1`
+(`netdata/src/go/plugin/framework/chartengine/autogen.go:291`). Therefore the
+frontend must support both pure numeric bucket IDs and prefixed bucket IDs, with
+pure numeric IDs treated as the primary production shape.
+
+The OTel plugin emits dimension names as pure numeric strings or the literal
+`+Inf` (`netdata/src/crates/netdata-otel/otel-plugin/src/metrics_service.rs:207-214`):
+
+```
+0.005, 0.01, 0.025, ..., 5, 10, +Inf
+```
+
+No units, no arbitrary strings. The frontend regex
+`(.+)_(\d+?\.?(\d+)?|\+[Ii]nf)$` (`src/helpers/heatmap.js:19`) requires a
+prefix; for OTel heatmaps the chart type is set directly
+(`ChartType::Heatmap` at `metrics_service.rs:187`), bypassing regex detection.
+
+### Existing unit scaling infrastructure (verified, must be reused)
+
+The codebase has a mature unit scaling system. **This SOW reuses it, does not
+reinvent it.**
+
+- `src/helpers/units/scalableUnits.js` — canonical prefix tables (pure data,
+  no chart deps):
+  - `binary`: `["1", "Ki", "Mi", "Gi", "Ti"]` (1024-based)
+  - `num`: `["y","z","a","f","p","n","u","m","1","k","M","G","T","P","E","Z","Y"]` (full SI, 1000-based)
+  - `decimal`: `["1", "K", "M", "B", "T"]`
+  - `chronos`: `["ns", "us", "ms", "s", "m", "h", "d", "mo", "y"]`
+  - `bit`: `["1", "k", "M", "G", "T", "P", "E", "Z", "Y"]`
+- `src/helpers/units/all.js` — 4000+ lines of unit configs with flags
+  (`is_scalable`, `is_metric`, `is_binary`, `is_chronos`, `is_bit`).
+- `src/helpers/units/index.js` — `getScales(unit)` dispatches to the right
+  table based on unit flags; `getUnitConfig`, `getUnitsString`.
+- `src/helpers/unitConversion/getConversionUnits.js` —
+  `getConversionAttributes(chart, unit, {min, max})` picks ONE prefix for a
+  chart axis based on the min/max delta (magnitude-based).
+- `src/sdk/makeChart/index.js:138` — `getConvertedValue` ties conversion +
+  `Intl.NumberFormat` together.
+
+**Gap (why we can't call the existing system directly):** The existing
+conversion is **axis-wide** — it picks ONE prefix per chart based on the
+min/max range, then applies that prefix to all values on that axis. Heatmap
+tick labels need **per-value** formatting: each bucket is a different value
+(`0.005`, `0.01`, `0.025`, ..., `10`, `+Inf`) and must be independently scaled
+(`0.005 → "5m"`, `10 → "10"`, `1024 → "1Ki"`). Axis-wide scaling would leave
+Prom-default buckets (delta ~10) with no prefix at all — defeating the purpose.
+
+**What we reuse:** the `scalableUnits` prefix tables (canonical definitions —
+what "Ki" means = 1024, what "m" means = 0.001). **What is genuinely new:**
+per-value formatting math (pick prefix per value from the table, divide,
+round, format), and the value-inference layer (binary vs SI detection).
+
+### Industry reference
+
+Grafana's heatmap (`public/app/plugins/panel/heatmap/fields.ts:142-148`,
+`calculateHeatmap/heatmap.ts:72-74,99-101,333`):
+- Numeric sort with `+Inf` → `Infinity`, fallback to payload order if any
+  non-numeric.
+- Label formatting is **config-driven** via the chart's unit (bytes → IEC,
+  short → SI). Grafana does **not** infer from values — but Grafana has
+  per-panel configuration. Netdata has automated dashboards and must infer.
+
+### Constraints
+
+- Bucket boundaries carry **no unit metadata**. The chart's `units` attribute
+  describes the cell values (e.g. `requests/s`), not the y-axis quantity.
+- The histogram's actual quantity (latency, size, etc.) is unknowable from
+  metadata — it must be inferred from the values for humanized labels.
+- Must not break non-numeric heatmaps (categorical dimensions, mixed sources).
+
+## Decisions (Locked)
+
+All decisions below were discussed and confirmed before this SOW was written.
+
+### Decision 1: Fix lives in the frontend
+
+- **A.** Frontend numeric sort in `makeDimensions` — **CHOSEN**.
+- B. Core agent presentation sort at API boundary (follow-up, separate work).
+- C. Core agent storage reorder — rejected (infeasible: RRD historical pages +
+  streaming + SQLite migration).
+
+**Rationale:** The frontend is the last hop and the only way to be robust
+against every upstream source (agent, Prom remote-write, future collectors).
+The agent bug is tracked separately; the frontend must defend regardless.
+
+### Decision 2: Sort fallback rule
+
+Parse with strict digits+dot. If any value (except `+Inf`) is non-numeric,
+fall back to payload order.
+
+- Pure numbers (`0.005`, `5`, `10000`) → numeric sort.
+- `+Inf` / `+inf` → sort to end (as `Infinity`).
+- Anything non-numeric (`5ms`, `low`, `5e3`, `0x10`, empty) → `NaN` →
+  fallback to payload order for the whole chart.
+
+### Decision 3: `+Inf` handling
+
+`+Inf` always sorts to the end and always renders as the literal `"+Inf"`,
+regardless of scale. Matches OTel plugin convention
+(`netdata/.../output.rs:117`).
+
+### Decision 4: Label scaling — value-inferred, reuse existing tables
+
+Three rules, applied in order:
+
+1. If all values except `+Inf` are purely numeric → sort numerically.
+2. If all numeric values **> 1** are power-of-2 → use the **binary** scale
+   table (`scalableUnits.binary`: `Ki`, `Mi`, `Gi`, ...).
+3. Otherwise → use the **num** (SI) scale table (`scalableUnits.num`: `m`,
+   `k`, `M`, `G`, ...).
+
+**Power-of-2 scope: only values > 1.** Sub-1 fractional values like `0.25`,
+`0.5` are excluded from the power-of-2 check (they are valid in latency
+histograms and must not trigger binary scaling). Confirmed by user.
+
+**Reuse, not reinvention:** the prefix tables (`scalableUnits.binary`,
+`scalableUnits.num`) are imported from the existing
+`src/helpers/units/scalableUnits.js`. The per-value formatting math is new
+(because the existing system is axis-wide, not per-value), but it reads from
+the canonical tables — single source of truth for what each prefix means.
+
+**Why value-based inference:** Netdata has automated dashboards and no unit
+metadata for bucket boundaries. Value-based inference is the only viable path.
+This diverges from Grafana (which uses config) because Netdata's UX contract
+is different (zero-config dashboards).
+
+### Decision 5: Isolated algorithm module
+
+The entire ordering + scaling algorithm must live in one pure, standalone
+module. It imports only `scalableUnits` (pure data) from the existing codebase
+— no chart, dygraph, SDK, or provider imports. All consumers import from it
+and contain no algorithm logic themselves.
+
+## Algorithm Specification
+
+### Pure module: `src/helpers/heatmapScale.js`
+
+All functions are pure. No side effects, no `this`, no I/O, no chart access.
+Imports ONLY `scalableUnits` from `@/helpers/units/scalableUnits` (pure data
+tables — no chart/dygraph/SDK dependencies).
+
+#### Parsing
+
+```
+parseHeatmapValue(str)
+  Input:  string | null | undefined
+  Output: number | NaN
+  Rules:
+    - "+Inf" or "+inf" (case-insensitive on "inf") → Infinity
+    - matches /^\d*\.?\d+$/ → parseFloat result
+    - everything else (5ms, 5e3, 0x10, "", null, undefined, "abc") → NaN
+```
+
+Strict regex `^\d*\.?\d+$` rejects scientific notation and units. This matches
+the agent's emission format (Display::<f64> of f64 boundaries, or literal
+"+Inf").
+
+#### Detection
+
+```
+isHeatmapNumeric(values)
+  Input:  string[] (dimension IDs, e.g. ["0.005", "0.01", "+Inf"])
+  Output: boolean
+  Rule:   true iff every value except "+Inf"/"+inf" parses to a finite number
+          (NaN → false). "+Inf" alone is allowed.
+
+isHeatmapBinary(values)
+  Input:  string[] (assumed already numeric — caller checks isHeatmapNumeric)
+  Output: boolean
+  Rule:   true iff every finite value > 1 is an integer power of 2
+          (n > 0 && Number.isInteger(n) && (n & (n-1)) === 0)
+          Values <= 1 and +Inf are ignored by this check.
+```
+
+#### Scale selection
+
+```
+detectHeatmapScale(values)
+  Input:  string[]
+  Output: "binary" | "num" | null
+  Rule:
+    - null   if !isHeatmapNumeric(values)  (caller falls back to payload order)
+    - "binary" if isHeatmapBinary(values)  → maps to scalableUnits.binary
+    - "num"    otherwise                   → maps to scalableUnits.num
+```
+
+The output keys (`"binary"`, `"num"`) match the keys in
+`scalableUnits` directly — no translation layer needed.
+
+#### Sorting
+
+```
+sortHeatmapValues(values)
+  Input:  string[]
+  Output: string[] | null
+  Rule:
+    - null  if !isHeatmapNumeric(values)  (caller falls back to payload order)
+    - otherwise, returns a NEW array sorted ascending by parseHeatmapValue,
+      with "+Inf"/"+inf" always last. Stable sort. Input array untouched.
+    - Original strings preserved in output (case of "+inf" not normalized).
+```
+
+#### Per-value formatting (new math, existing tables)
+
+```
+formatScaledValue(value, scale)
+  Input:  value: number (finite, >= 0)
+          scale: "binary" | "num"
+  Output: string
+  Rule:
+    - Looks up scalableUnits[scale] for the prefix table.
+    - Finds the largest prefix divisor where value / divisor >= 1
+      (or the raw value if none fits — small values stay raw).
+    - Divides, formats with up to 2 significant decimals, strips trailing
+      zeros, appends the prefix symbol (e.g. " Ki", " m", " k").
+    - Examples (scale="num"):  0.005 → "5m", 1500 → "1.5k", 1000000 → "1M"
+    - Examples (scale="binary"): 1024 → "1Ki", 1536 → "1.5Ki", 1048576 → "1Mi"
+    - Value 0 → "0".
+
+formatHeatmapLabel(str, scale)
+  Input:  str: string (the raw dimension label, e.g. "0.005" or "+Inf")
+          scale: "binary" | "num" | null
+  Output: string
+  Rule:
+    - "+Inf"/"+inf" → "+Inf" (always, regardless of scale)
+    - null scale     → str as-is (fallback path — no inference)
+    - "binary"/"num" → parse + formatScaledValue(parseHeatmapValue(str), scale)
+    - unparseable     → str as-is (defensive passthrough)
+```
+
+### Integration: thin consumers
+
+Consumers contain **no algorithm logic** — they call the module.
+
+#### `src/sdk/makeChart/makeDimensions.js`
+
+In `updateDimensions()`, after heatmap detection, compute and store:
+
+- `heatmapSortedIds` — `sortHeatmapValues(dimensionIds)` (may be `null`)
+- `heatmapScale` — `detectHeatmapScale(dimensionIds)` (may be `null`)
+
+Expose (read-only getters, no reactivity needed beyond existing
+`dimensionChanged` trigger):
+
+- `chart.getHeatmapSortedIds()` → `string[] | null`
+- `chart.getHeatmapScale()` → `"binary" | "num" | null`
+- `chart.getHeatmapYIndex(id)` → position in `heatmapSortedIds`, else payload
+  index via `getDimensionIndex(id)` when `heatmapSortedIds` is `null`.
+
+**Critical:** `getDimensionIndex`, `dimensionsById`, and all data-access
+methods (`getRowDimensionValue`, `getDimensionName`, `getDimensionUnit`, etc.)
+remain **unchanged** — they keep returning payload index. The heatmap y-index
+is a separate concept used only for rendering position.
+
+#### `src/chartLibraries/dygraph/plotters/heatmap.js`
+
+Switch the y-position source:
+- Before: `const index = chartUI.chart.getDimensionIndex(seriesName)`
+- After:  `const index = chartUI.chart.getHeatmapYIndex(seriesName)`
+
+Value lookup changes to use `seriesName` directly (not `dimensionIds[index]`),
+removing the fragile indirection.
+
+#### `src/chartLibraries/dygraph/tickers/heatmap.js`
+
+Receive `sortedIds` and `scale` (passed from `index.js`). Format each label
+via `formatHeatmapLabel(withoutPrefix(id), scale)`. Tick positions (index-based)
+are unchanged.
+
+#### `src/chartLibraries/dygraph/index.js:333`
+
+Pass `heatmapSortedIds` (or fall back to `getVisibleDimensionIds`) and
+`heatmapScale` into the ticker options.
+
+## File Changes Summary
+
+| File | Change |
+|---|---|
+| `src/helpers/heatmapScale.js` | **NEW** — pure algorithm module (imports `scalableUnits` only) |
+| `src/helpers/heatmapScale.test.js` | **NEW** — exhaustive unit tests |
+| `src/sdk/makeChart/makeDimensions.js` | compute + expose sorted IDs, scale, y-index |
+| `src/sdk/makeChart/makeDimensions.test.js` | tests for new getters and update path |
+| `src/chartLibraries/dygraph/plotters/heatmap.js` | use `getHeatmapYIndex` |
+| `src/chartLibraries/dygraph/plotters/heatmap.test.js` | update tests for sorted positions |
+| `src/chartLibraries/dygraph/tickers/heatmap.js` | format labels via `formatHeatmapLabel` |
+| `src/chartLibraries/dygraph/tickers/heatmap.test.js` | tests for formatted labels |
+| `src/chartLibraries/dygraph/index.js` | pass sorted IDs + scale to ticker |
+
+## Test Plan
+
+### Pure module tests (`heatmapScale.test.js`)
+
+Exhaustive, isolated. **No mocks, no chart, no dygraph** (per AGENTS.md
+testing rules). Pure function input/output assertions.
+
+**`parseHeatmapValue`:**
+- Integers: `"0"` → `0`, `"5"` → `5`, `"10000"` → `10000`
+- Decimals: `"0.005"` → `0.005`, `"2.5"` → `2.5`, `".5"` → `0.5`
+- `"5."` (trailing dot) → `NaN` (regex `\d+` requires digits after dot)
+- `+Inf` variants: `"+Inf"` → `Infinity`, `"+inf"` → `Infinity`, `"-Inf"` → `NaN`, `"Inf"` → `NaN` (no leading +)
+- Rejected (→ `NaN`): `"5ms"`, `"5e3"`, `"0x10"`, `"abc"`, `""`, `null`, `undefined`, `" "`, `"+5"`, `"-5"`, `"1,000"`
+
+**`isHeatmapNumeric`:**
+- `["0.005", "0.01", "+Inf"]` → `true`
+- `["1", "2", "5", "10", "+Inf"]` → `true`
+- `["5ms", "1", "+Inf"]` → `false`
+- `["+Inf"]` → `true` (single +Inf is valid)
+- `[]` → `true` (vacuous — caller handles empty)
+- `["0", "5", "10"]` → `true` (zero is numeric)
+
+**`isHeatmapBinary`:**
+- `["1024", "2048", "4096", "+Inf"]` → `true`
+- `["1", "2", "4", "8"]` → `true`
+- `["0.25", "0.5", "1", "2", "4"]` → `true` (sub-1 fractions ignored by the >1 rule)
+- `["0", "5", "10"]` → `false` (5 and 10 are not powers of 2)
+- `["1000", "2000"]` → `false`
+- `["3", "5", "+Inf"]` → `false`
+
+**`detectHeatmapScale`:**
+- `["1024", "2048", "+Inf"]` → `"binary"`
+- `["0.005", "0.01", "+Inf"]` → `"num"` (no values > 1, vacuously not binary, falls to SI)
+- `["0", "5", "10", "+Inf"]` → `"num"`
+- `["5ms", "1"]` → `null` (not numeric)
+- `[]` → `null` (no data → no inference)
+
+**`sortHeatmapValues`:**
+- `["5", "1", "10", "+Inf"]` → `["1", "5", "10", "+Inf"]`
+- `["10", "+Inf", "1", "5"]` → `["1", "5", "10", "+Inf"]`
+- `["0.25", "0.005", "1", "+Inf"]` → `["0.005", "0.25", "1", "+Inf"]`
+- Input array not mutated (verify reference inequality)
+- `["5ms", "1"]` → `null`
+- `["+inf", "1"]` (lowercase) → `["1", "+inf"]` (preserve original string)
+- Empty `[]` → `[]`
+
+**`formatScaledValue`:**
+- SI (`"num"`): `0.005` → `"5m"`, `0.001` → `"1m"`, `500` → `"500"`, `1000` → `"1k"`, `1500` → `"1.5k"`, `1000000` → `"1M"`, `0` → `"0"`
+- Binary (`"binary"`): `500` → `"500"`, `1023` → `"1023"`, `1024` → `"1Ki"`, `1536` → `"1.5Ki"`, `1048576` → `"1Mi"`, `0` → `"0"`
+- Trailing zero stripping: `1.50k` → `"1.5k"`, `1.00k` → `"1k"`
+
+**`formatHeatmapLabel`:**
+- `("+Inf", "num")` → `"+Inf"`
+- `("+Inf", "binary")` → `"+Inf"`
+- `("+Inf", null)` → `"+Inf"`
+- `("0.005", "num")` → `"5m"`
+- `("1024", "binary")` → `"1Ki"`
+- `("5ms", "num")` → `"5ms"` (unparseable, defensive passthrough)
+- `("0.005", null)` → `"0.005"` (fallback, raw)
+
+### Required source-shape fixtures
+
+- Live Prometheus-style payload: pure numeric IDs/names plus `+Inf`, including
+  lexically broken order such as `["10", "120", "15", "1920", "2"]`.
+- OTel-style payload: pure `explicit_bounds` strings plus final `+Inf`.
+- Compatibility payload: prefixed bucket IDs such as `bucket_1`, `bucket_2`,
+  `bucket_+Inf`, because Netdata chartengine can still generate internal
+  prefixed dimension names.
+- Fallback payload: any non-numeric bucket value preserves payload order.
+
+### Integration tests
+
+**`makeDimensions.test.js`:**
+- Heatmap with numeric buckets → `getHeatmapSortedIds()` returns ascending,
+  `getHeatmapScale()` returns `"num"` or `"binary"` correctly.
+- Heatmap with non-numeric bucket → `getHeatmapSortedIds()` returns `null`,
+  `getHeatmapScale()` returns `null`.
+- `getHeatmapYIndex` returns sorted position when sorted, payload index when
+  `null`.
+- Runtime-added bucket (simulate by appending to `dimensionIds` and calling
+  `updateDimensions`) → sorted order reflects new bucket correctly.
+
+**`plotters/heatmap.test.js`:**
+- Render with out-of-order numeric buckets → verify rows drawn at sorted
+  y-positions (not payload positions).
+- Render with non-numeric buckets → verify fallback to payload order (existing
+  behavior preserved).
+
+**`tickers/heatmap.test.js`:**
+- Ticker with `"num"` scale → labels formatted with SI prefixes from
+  `scalableUnits.num`.
+- Ticker with `"binary"` scale → labels formatted with binary prefixes from
+  `scalableUnits.binary`.
+- Ticker with `null` scale → labels via `withoutPrefix` (existing behavior).
+- `+Inf` always renders as `"+Inf"`.
+
+### Testing rules (per AGENTS.md)
+
+- **No mocks.** Real imports, real chart via `makeTestChart`.
+- Existing tests must still pass (zero regressions).
+- Use `makeTestChart` from `@jest/testUtilities` for integration tests.
+
+## Acceptance Criteria
+
+1. **Bug fixed:** runtime-added bucket renders in correct numeric position,
+   not at the bottom. Verified by a test that simulates
+   `["1", "2", "5", "10", "+Inf"]` then appends `"3"` and re-renders.
+2. **Fallback preserved:** non-numeric heatmap dimensions fall back to payload
+   order. Zero behavior change for categorical/mixed heatmaps.
+3. **Labels scaled:** binary buckets render with `Ki/Mi/Gi` (from
+   `scalableUnits.binary`), SI buckets with `m/k/M/G` (from
+   `scalableUnits.num`), per the locked rules.
+4. **`+Inf` always last and always labeled `"+Inf"`.**
+5. **Pure module isolated:** `heatmapScale.js` imports only
+   `scalableUnits` (pure data). No chart, dygraph, SDK, or provider imports.
+   Independently unit-testable.
+6. **Reuses existing infrastructure:** prefix tables come from
+   `scalableUnits.js`, not invented. Per-value formatting is new (documented
+   gap — existing system is axis-wide).
+7. **No regressions:** all existing heatmap tests pass unchanged.
+8. **Code style:** no semicolons, double quotes, 2-space indent, ES5 trailing
+   commas — matches repo conventions.
+9. **Lint and tests pass:** `yarn lint`, `yarn test`.
+
+## Out of Scope
+
+- Y-axis numeric scaling (linear/log/symlog row heights) — separate feature,
+  not part of this bug fix. Current ordinal (equal-height) layout preserved.
+- Core agent storage reorder — rejected (infeasible). Tracked separately.
+- Per-chart unit configuration for bucket labels — Netdata is zero-config;
+  value inference is the chosen path.
+- X-axis changes — only y-axis (bucket axis) is in scope.
+- Refactoring the existing axis-wide conversion system to support per-value
+  formatting — would be a cross-cutting change affecting all charts. The
+  per-value formatting here is heatmap-specific and isolated.
+
+## Formatting Decisions (Locked)
+
+1. SI micro prefix (`u` in the table) — values < 0.001 (e.g. `0.0001`) format
+   with the existing `scalableUnits.num` table, e.g. `"100u"`.
+2. Prefix spacing — compact labels are chosen: `"5m"`, `"1.5k"`, `"1Mi"`.
+   This is shorter and fits better in narrow y-axis space. Confirmed by user.
+3. Decimal count — up to 2 decimal places, stripping trailing zeros.

--- a/jest/testUtilities/heatmapPayload.js
+++ b/jest/testUtilities/heatmapPayload.js
@@ -1,0 +1,61 @@
+export const makeHeatmapPayload = (ids, rows, { timestamp = 1000 } = {}) => {
+  const emptyStats = ids.map(() => 0)
+  const priorities = ids.map((_, index) => index)
+
+  return {
+    api: 2,
+    summary: {
+      nodes: [{ mg: "node-1", nd: "node-1", nm: "node-1", ni: 0 }],
+      contexts: [{ id: "prometheus.test.histogram", sts: { min: 0, max: 3, avg: 0, con: 0 } }],
+      instances: [],
+      dimensions: ids.map((id, index) => ({
+        id,
+        pri: index,
+        sts: { min: 0, max: 3, avg: 0, con: 0 },
+      })),
+      labels: [],
+      alerts: [],
+    },
+    db: {
+      update_every: 1,
+      first_entry: 1,
+      last_entry: 2,
+    },
+    view: {
+      title: "Heatmap",
+      update_every: 1,
+      units: "requests/s",
+      chart_type: "heatmap",
+      dimensions: {
+        grouped_by: ["dimension"],
+        ids,
+        names: ids,
+        units: ids.map(() => "requests/s"),
+        priorities,
+        aggregated: ids.map(() => 1),
+        sts: {
+          min: emptyStats,
+          max: emptyStats,
+          avg: emptyStats,
+          arp: emptyStats,
+          con: emptyStats,
+        },
+      },
+      min: 0,
+      max: 3,
+    },
+    result: {
+      labels: ["time", ...ids],
+      point: { value: 0, arp: 1, pa: 2 },
+      data: rows.map((values, index) => [
+        timestamp + index * 1000,
+        ...values.map(value => [value, 0, 0]),
+      ]),
+    },
+  }
+}
+
+export const loadHeatmapPayload = async (chart, ids, rows, options) => {
+  chart.doneFetch(makeHeatmapPayload(ids, rows, options))
+  await new Promise(resolve => setTimeout(resolve, 0))
+}

--- a/jest/testUtilities/index.js
+++ b/jest/testUtilities/index.js
@@ -1,2 +1,3 @@
 export { renderWithChart, renderHookWithChart, renderWithProviders } from "./renderUtils"
 export { makeTestChart } from "./makeTestChart"
+export { loadHeatmapPayload, makeHeatmapPayload } from "./heatmapPayload"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/cli": "^7.28.6",
     "@babel/core": "^7.29.0",
     "@babel/eslint-parser": "^7.28.6",
+    "@babel/plugin-syntax-optional-chaining": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.29.0",
     "@babel/preset-env": "^7.29.0",
     "@babel/preset-react": "^7.28.5",

--- a/src/chartLibraries/dygraph/hoverX.js
+++ b/src/chartLibraries/dygraph/hoverX.js
@@ -1,4 +1,5 @@
 import getOffsets from "@/helpers/eventOffset"
+import { isHeatmap } from "@/helpers/heatmap"
 
 const shouldFindMaxValue = {
   stacked: true,
@@ -6,6 +7,28 @@ const shouldFindMaxValue = {
 }
 
 export default chartUI => {
+  const getClosestHeatmapDimension = offsetY => {
+    const ids = chartUI.chart.getVisibleHeatmapIds?.()
+    if (!ids?.length) return
+
+    const dygraph = chartUI.getDygraph()
+    let closestId
+    let closestDistance = Infinity
+
+    ids.forEach((id, index) => {
+      const y = dygraph.toDomYCoord(index)
+      if (!Number.isFinite(y)) return
+
+      const distance = Math.abs(y - offsetY)
+      if (distance < closestDistance) {
+        closestId = id
+        closestDistance = distance
+      }
+    })
+
+    return closestId
+  }
+
   const findClosest = (event, points) => {
     if (!Array.isArray(points)) return {}
 
@@ -15,6 +38,11 @@ export default chartUI => {
 
     if (offsetY > _dygraph.getArea().h - 10) return { seriesName: "ANNOTATIONS" }
     if (offsetY < 15) return { seriesName: "ANOMALY_RATE" }
+
+    if (isHeatmap(chartUI.chart)) {
+      const dimensionId = getClosestHeatmapDimension(offsetY)
+      return dimensionId ? { dimensionId } : {}
+    }
 
     if (shouldFindMaxValue[chartUI.chart.getAttribute("chartType")]) {
       let closestPoint = _dygraph.findStackedPoint(offsetX, offsetY)
@@ -42,7 +70,9 @@ export default chartUI => {
   let lastTimestamp
 
   const getDimension = (event, points) => {
-    const { seriesName } = findClosest(event, points)
+    const { seriesName, dimensionId } = findClosest(event, points)
+
+    if (dimensionId) return dimensionId
 
     if (!seriesName) return
 

--- a/src/chartLibraries/dygraph/hoverX.test.js
+++ b/src/chartLibraries/dygraph/hoverX.test.js
@@ -174,6 +174,53 @@ describe("hoverX", () => {
     expect(chartUI.sdk.trigger).toHaveBeenCalledWith("highlightHover", chart, 1640995200000, "test")
   })
 
+  it("selects heatmap bucket from cursor y instead of dygraph nearest point", () => {
+    const visibleHeatmapIds = ["low", "mid", "high"]
+    const findClosestPoint = jest.fn(() => ({ seriesName: "low", row: 0 }))
+
+    chart.getAttribute = jest.fn(key => {
+      if (key === "chartType") return "heatmap"
+      if (key === "overlays") return {}
+      return null
+    })
+    chart.getVisibleHeatmapIds = jest.fn(() => visibleHeatmapIds)
+    chart.getPayloadDimensionIds = jest.fn(() => visibleHeatmapIds)
+
+    chartUI.getDygraph = jest.fn(() => ({
+      getArea: jest.fn(() => ({ h: 200 })),
+      findClosestPoint,
+      getPropertiesForSeries: jest.fn(seriesName => ({
+        column: visibleHeatmapIds.findIndex(id => id === seriesName) + 1,
+      })),
+      toDomYCoord: jest.fn(index => {
+        const positions = [150, 100, 50]
+        return positions[index]
+      }),
+    }))
+
+    hoverXInstance.toggle(true)
+
+    const highlightHandler = chartUI.on.mock.calls.find(call => call[0] === "highlightCallback")[1]
+
+    highlightHandler(
+      {
+        clientX: 100,
+        clientY: 100,
+        target: { getBoundingClientRect: () => ({ left: 0, top: 0 }) },
+      },
+      1640995200000,
+      []
+    )
+
+    expect(findClosestPoint).not.toHaveBeenCalled()
+    expect(chartUI.sdk.trigger).toHaveBeenCalledWith(
+      "highlightHover",
+      chart,
+      1640995200000,
+      "mid"
+    )
+  })
+
   it("handles destroy method", () => {
     hoverXInstance.toggle(true)
     hoverXInstance.destroy()

--- a/src/chartLibraries/dygraph/index.js
+++ b/src/chartLibraries/dygraph/index.js
@@ -292,7 +292,8 @@ export default (sdk, chart) => {
           prevMax = max
           chart.trigger("yAxisChange", min, max)
         }
-        const value = parseFloat(parseFloat(y).toFixed(5))
+        const parsed = Number(y)
+        const value = isFinite(parsed) ? parseFloat(parsed.toFixed(5)) : NaN
         return isNaN(value) ? y : value
       },
       makeYTicker:
@@ -330,7 +331,11 @@ export default (sdk, chart) => {
 
     const yAxisLabelFormatter = makeYAxisLabelFormatter(labels)
     const yTicker = makeYTicker
-      ? makeYTicker({ labels: chart.getVisibleDimensionIds(), units: chart.getUnits() })
+      ? makeYTicker({
+          labels: chart.getVisibleHeatmapIds?.() || chart.getVisibleDimensionIds(),
+          scale: chart.getHeatmapScale?.(),
+          units: chart.getUnits(),
+        })
       : null
 
     const { selectedLegendDimensions } = chart.getAttributes()

--- a/src/chartLibraries/dygraph/index.js
+++ b/src/chartLibraries/dygraph/index.js
@@ -409,6 +409,7 @@ export default (sdk, chart) => {
     const { data, labels } = chart.getPayload()
     const dateWindow = chart.getDateWindow()
     const isEmpty = outOfLimits || data.length === 0
+    const heatmapIds = isHeatmap(chartType) ? chart.getVisibleHeatmapIds() : null
 
     return {
       file: isEmpty ? [[0]] : data,
@@ -417,7 +418,7 @@ export default (sdk, chart) => {
       valueRange: staticValueRange
         ? staticValueRange
         : isHeatmap(chartType)
-          ? [0, chart.getVisibleDimensionIds().length]
+          ? [0, heatmapIds.length]
           : getValueRange(chart, { dygraph: true }),
     }
   }

--- a/src/chartLibraries/dygraph/index.test.js
+++ b/src/chartLibraries/dygraph/index.test.js
@@ -1,4 +1,4 @@
-import { makeTestChart } from "@jest/testUtilities"
+import { loadHeatmapPayload, makeTestChart } from "@jest/testUtilities"
 import dygraphChart from "./index"
 
 const mockDygraph = {
@@ -302,6 +302,41 @@ describe("dygraphChart", () => {
     expect(formatter("1k")).toBe("1k")
     expect(formatter("+Inf")).toBe("+Inf")
     expect(formatter("0.005")).toBe(0.005)
+  })
+
+  it("uses cropped heatmap bucket count for y-axis range", async () => {
+    const ids = ["0", "1", "2", "3", "4", "5", "6"]
+    const { sdk, chart } = makeTestChart({
+      attributes: {
+        chartType: "heatmap",
+        groupBy: ["dimension"],
+        selectedLegendDimensions: [],
+        viewDimensions: {
+          ids,
+          names: ids,
+          priorities: ids.map((_, index) => index),
+          units: ids.map(() => ""),
+          contexts: ids.map(() => ""),
+          grouped: ["dimension"],
+        },
+      },
+    })
+
+    await loadHeatmapPayload(chart, ids, [[0, 0, 1, 0, 2, 0, 0]], {
+      timestamp: 1617946860000,
+    })
+    chart.getDateWindow = () => [1617946860000, 1617947750000]
+    chart.formatXAxis = x => x.toString()
+    chart.getThemeAttribute = () => "#333"
+    chart.getUnitSign = () => ""
+
+    const instance = dygraphChart(sdk, chart)
+    instance.mount(document.createElement("div"))
+
+    const Dygraph = require("dygraphs")
+    const options = Dygraph.mock.calls[Dygraph.mock.calls.length - 1][2]
+
+    expect(options.valueRange).toEqual([0, 5])
   })
 
   it("returns axis range from dygraph", () => {

--- a/src/chartLibraries/dygraph/index.test.js
+++ b/src/chartLibraries/dygraph/index.test.js
@@ -263,6 +263,47 @@ describe("dygraphChart", () => {
     )
   })
 
+  it("preserves compact scaled heatmap y-axis labels", () => {
+    const ids = ["0.005", "1000", "+Inf"]
+    const { sdk, chart } = makeTestChart({
+      attributes: {
+        chartType: "heatmap",
+        groupBy: ["dimension"],
+        selectedLegendDimensions: [],
+        viewDimensions: {
+          ids,
+          names: ids,
+          priorities: ids.map((_, index) => index),
+          units: ids.map(() => ""),
+          contexts: ids.map(() => ""),
+          grouped: ["dimension"],
+        },
+      },
+    })
+
+    chart.updateDimensions()
+    chart.getPayload = () => ({
+      data: [[1617946860000, 1, 2, 3]],
+      labels: ["time", "0.005", "1000", "+Inf"],
+    })
+    chart.getDateWindow = () => [1617946860000, 1617947750000]
+    chart.formatXAxis = x => x.toString()
+    chart.getThemeAttribute = () => "#333"
+    chart.getUnitSign = () => ""
+
+    const instance = dygraphChart(sdk, chart)
+    instance.mount(document.createElement("div"))
+
+    const Dygraph = require("dygraphs")
+    const options = Dygraph.mock.calls[Dygraph.mock.calls.length - 1][2]
+    const formatter = options.axes.y.axisLabelFormatter
+
+    expect(formatter("5m")).toBe("5m")
+    expect(formatter("1k")).toBe("1k")
+    expect(formatter("+Inf")).toBe("+Inf")
+    expect(formatter("0.005")).toBe(0.005)
+  })
+
   it("returns axis range from dygraph", () => {
     const { sdk, chart } = makeTestChart()
 

--- a/src/chartLibraries/dygraph/plotters/heatmap.js
+++ b/src/chartLibraries/dygraph/plotters/heatmap.js
@@ -33,7 +33,8 @@ export default chartUI => plotter => {
     )
 
     sets[j].forEach((p, i) => {
-      const value = chartUI.chart.getDimensionValue(seriesName, i, { allowNull: true })
+      const rowIndex = Number.isInteger(p.idx) ? p.idx : i
+      const value = chartUI.chart.getDimensionValue(seriesName, rowIndex, { allowNull: true })
 
       ctx.fillStyle = getColor(value)
       ctx.fillRect(p.canvasx - barWidth / 2, g.toDomYCoord(index) - height / 2, barWidth, height)

--- a/src/chartLibraries/dygraph/plotters/heatmap.js
+++ b/src/chartLibraries/dygraph/plotters/heatmap.js
@@ -6,8 +6,6 @@ export default chartUI => plotter => {
   // We need to handle all the series simultaneously.
   if (plotter.seriesIndex !== 0) return
 
-  const dimensionIds = chartUI.chart.getVisibleDimensionIds()
-
   const g = plotter.dygraph
   const ctx = plotter.drawingContext
   const sets = plotter.allSeriesPoints
@@ -24,7 +22,7 @@ export default chartUI => plotter => {
   const getColor = makeGetColor(chartUI.chart)
 
   series.forEach((seriesName, j) => {
-    const index = chartUI.chart.getDimensionIndex(seriesName)
+    const index = chartUI.chart.getHeatmapYIndex(seriesName)
 
     if (index === -1) return
 
@@ -35,7 +33,7 @@ export default chartUI => plotter => {
     )
 
     sets[j].forEach((p, i) => {
-      const value = chartUI.chart.getDimensionValue(dimensionIds[index], i, { allowNull: true })
+      const value = chartUI.chart.getDimensionValue(seriesName, i, { allowNull: true })
 
       ctx.fillStyle = getColor(value)
       ctx.fillRect(p.canvasx - barWidth / 2, g.toDomYCoord(index) - height / 2, barWidth, height)

--- a/src/chartLibraries/dygraph/plotters/heatmap.test.js
+++ b/src/chartLibraries/dygraph/plotters/heatmap.test.js
@@ -124,6 +124,22 @@ describe("heatmap plotter", () => {
     expect(chartUI.chart.getDimensionValue).toHaveBeenCalledWith("2", 0, { allowNull: true })
   })
 
+  it("reads values by dygraph payload row index when points are clipped", () => {
+    plotter.allSeriesPoints = [
+      [
+        { canvasx: 10, idx: 4 },
+        { canvasx: 20, idx: 5 },
+      ],
+    ]
+    plotter.dygraph.layout_.setNames = ["dim1"]
+
+    const plotterFunc = heatmapPlotter(chartUI)
+    plotterFunc(plotter)
+
+    expect(chartUI.chart.getDimensionValue).toHaveBeenCalledWith("dim1", 4, { allowNull: true })
+    expect(chartUI.chart.getDimensionValue).toHaveBeenCalledWith("dim1", 5, { allowNull: true })
+  })
+
   it("uses color based on dimension value", () => {
     const plotterFunc = heatmapPlotter(chartUI)
     plotterFunc(plotter)

--- a/src/chartLibraries/dygraph/plotters/heatmap.test.js
+++ b/src/chartLibraries/dygraph/plotters/heatmap.test.js
@@ -46,6 +46,7 @@ describe("heatmap plotter", () => {
       const map = { dim1: 0, dim2: 1, dim3: 2 }
       return map[name] ?? -1
     })
+    jest.spyOn(chart, "getHeatmapYIndex").mockImplementation(name => chart.getDimensionIndex(name))
     jest.spyOn(chart, "getDimensionValue").mockReturnValue(42)
     jest.spyOn(chart, "getAttribute").mockImplementation(attr => {
       if (attr === "max") return 100
@@ -87,11 +88,40 @@ describe("heatmap plotter", () => {
   })
 
   it("skips series with unknown dimension index", () => {
-    chartUI.chart.getDimensionIndex.mockReturnValue(-1)
+    chartUI.chart.getHeatmapYIndex.mockReturnValue(-1)
     const plotterFunc = heatmapPlotter(chartUI)
     plotterFunc(plotter)
 
     expect(ctx.fillRect).not.toHaveBeenCalled()
+  })
+
+  it("draws rows using sorted heatmap y-index while reading values by series id", () => {
+    plotter.allSeriesPoints = [
+      [{ canvasx: 10 }, { canvasx: 20 }],
+      [{ canvasx: 10 }, { canvasx: 20 }],
+      [{ canvasx: 10 }, { canvasx: 20 }],
+    ]
+    plotter.dygraph.layout_.setNames = ["+Inf", "0.3", "2"]
+    plotter.dygraph.toDomYCoord = jest.fn(index => 50 + index * 20)
+
+    chartUI.chart.getHeatmapYIndex.mockImplementation(id => {
+      const indexes = { "0.3": 0, 2: 1, "+Inf": 2 }
+      return indexes[id] ?? -1
+    })
+    chartUI.chart.getDimensionValue.mockImplementation(id => {
+      const values = { "0.3": 1, 2: 2, "+Inf": 3 }
+      return values[id]
+    })
+
+    const plotterFunc = heatmapPlotter(chartUI)
+    plotterFunc(plotter)
+
+    expect(ctx.fillRect.mock.calls[0][1]).toBe(80)
+    expect(ctx.fillRect.mock.calls[2][1]).toBe(40)
+    expect(ctx.fillRect.mock.calls[4][1]).toBe(60)
+    expect(chartUI.chart.getDimensionValue).toHaveBeenCalledWith("+Inf", 0, { allowNull: true })
+    expect(chartUI.chart.getDimensionValue).toHaveBeenCalledWith("0.3", 0, { allowNull: true })
+    expect(chartUI.chart.getDimensionValue).toHaveBeenCalledWith("2", 0, { allowNull: true })
   })
 
   it("uses color based on dimension value", () => {

--- a/src/chartLibraries/dygraph/tickers/heatmap.js
+++ b/src/chartLibraries/dygraph/tickers/heatmap.js
@@ -1,7 +1,8 @@
 import { withoutPrefix } from "@/helpers/heatmap"
+import { formatHeatmapLabel } from "@/helpers/heatmapScale"
 
-export default (a, b, pixels, opts, dygraph, vals, { labels: defaultLabels } = {}) => {
-  const labels = defaultLabels.map(withoutPrefix)
+export default (a, b, pixels, opts, dygraph, vals, { labels: defaultLabels = [], scale } = {}) => {
+  const labels = defaultLabels.map(label => formatHeatmapLabel(withoutPrefix(label), scale))
 
   const pixelsPerTick = opts("pixelsPerLabel")
   const maxTicks = Math.floor(pixels / pixelsPerTick)

--- a/src/chartLibraries/dygraph/tickers/heatmap.test.js
+++ b/src/chartLibraries/dygraph/tickers/heatmap.test.js
@@ -1,5 +1,4 @@
 import heatmapTicker from "./heatmap"
-import { withoutPrefix } from "@/helpers/heatmap"
 
 describe("heatmapTicker", () => {
   let mockOpts
@@ -67,6 +66,39 @@ describe("heatmapTicker", () => {
     heatmapTicker(0, 100, 200, mockOpts, mockDygraph, null, { labels: defaultLabels })
 
     expect(mockFormatter).toHaveBeenCalled()
+  })
+
+  it("formats SI heatmap bucket labels compactly", () => {
+    const defaultLabels = ["0.005", "1000", "+Inf"]
+    const ticks = heatmapTicker(0, 100, 300, mockOpts, mockDygraph, null, {
+      labels: defaultLabels,
+      scale: "num",
+    })
+
+    const labels = ticks.filter(tick => tick.v !== undefined).map(tick => tick.label)
+    expect(labels).toEqual(["label_5m", "label_1k", "label_+Inf"])
+  })
+
+  it("formats binary heatmap bucket labels compactly", () => {
+    const defaultLabels = ["512", "1024", "1048576", "+Inf"]
+    const ticks = heatmapTicker(0, 100, 300, mockOpts, mockDygraph, null, {
+      labels: defaultLabels,
+      scale: "binary",
+    })
+
+    const labels = ticks.filter(tick => tick.v !== undefined).map(tick => tick.label)
+    expect(labels).toEqual(["label_512", "label_1Ki", "label_1Mi", "label_+Inf"])
+  })
+
+  it("uses raw prefix-stripped labels when scale is null", () => {
+    const defaultLabels = ["bucket_0.005", "bucket_+Inf"]
+    const ticks = heatmapTicker(0, 100, 200, mockOpts, mockDygraph, null, {
+      labels: defaultLabels,
+      scale: null,
+    })
+
+    const labels = ticks.filter(tick => tick.v !== undefined).map(tick => tick.label)
+    expect(labels).toEqual(["label_0.005", "label_+Inf"])
   })
 
   it("calculates hidden step to reduce label density", () => {

--- a/src/components/line/popover/dimensions.js
+++ b/src/components/line/popover/dimensions.js
@@ -77,6 +77,7 @@ const rowSorting = {
 const Dimensions = () => {
   const chart = useChart()
   const [x, row] = useAttributeValue("hoverX") || emptyArray
+  const isHeatmap = chart.getAttribute("chartType") === "heatmap"
 
   const [from, to, total, ids] = useMemo(() => {
     const index = chart.getClosestRow(x)
@@ -91,12 +92,14 @@ const Dimensions = () => {
     const rowIndex = dimensionIds.findIndex(id => id === row)
 
     const total = dimensionIds.length
+    if (isHeatmap) return [0, total, total, dimensionIds]
+
     const from = Math.floor(getFrom(total, rowIndex))
     const to = Math.ceil(getTo(total, rowIndex))
     const ids = dimensionIds.slice(from, to)
 
     return [from, to, total, ids]
-  }, [chart, row, x])
+  }, [chart, isHeatmap, row, x])
 
   const rowFlavour = rowFlavours[row] || rowFlavours.default
 

--- a/src/components/line/popover/dimensions.test.js
+++ b/src/components/line/popover/dimensions.test.js
@@ -1,0 +1,71 @@
+import React from "react"
+import { screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import {
+  loadHeatmapPayload,
+  makeHeatmapPayload,
+  makeTestChart,
+  renderWithChart,
+} from "@jest/testUtilities"
+import Dimensions from "./dimensions"
+
+const loadLinePayload = async (chart, ids, rows) => {
+  const payload = makeHeatmapPayload(ids, rows)
+
+  payload.view.chart_type = "line"
+  payload.view.dimensions.grouped_by = []
+
+  chart.doneFetch(payload)
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe("line popover Dimensions", () => {
+  it("shows all cropped heatmap buckets without generic more-values windowing", async () => {
+    const ids = Array.from({ length: 14 }, (_, index) => String(index))
+    const row = ids.map((_, index) => (index > 1 && index < 12 ? 1 : 0))
+    const { chart } = makeTestChart({
+      attributes: {
+        chartType: "heatmap",
+        groupBy: ["dimension"],
+        selectedDimensions: [],
+        selectedLegendDimensions: [],
+      },
+    })
+
+    await loadHeatmapPayload(chart, ids, [row])
+    chart.updateAttribute("hoverX", [1000, "6"])
+
+    renderWithChart(<Dimensions />, { chart })
+
+    expect(chart.getVisibleHeatmapIds()).toEqual(ids.slice(1, 13))
+    expect(screen.queryByText(/more values/)).not.toBeInTheDocument()
+    expect(screen.getAllByTestId("chartPopover-dimension")).toHaveLength(12)
+    expect(screen.getAllByTestId("chartDimensions-name").map(node => node.textContent)).toEqual(
+      ids.slice(1, 13)
+    )
+  })
+
+  it("keeps generic more-values windowing for non-heatmap popovers", async () => {
+    const ids = Array.from({ length: 12 }, (_, index) => `dim${index}`)
+    const { chart } = makeTestChart({
+      attributes: {
+        chartType: "line",
+        groupBy: [],
+        selectedDimensions: [],
+        selectedLegendDimensions: [],
+      },
+    })
+
+    await loadLinePayload(
+      chart,
+      ids,
+      [ids.map((_, index) => index)]
+    )
+    chart.updateAttribute("hoverX", [1000, "not-a-dimension"])
+
+    renderWithChart(<Dimensions />, { chart })
+
+    expect(screen.getByText(/more values/)).toBeInTheDocument()
+    expect(screen.getAllByTestId("chartPopover-dimension")).toHaveLength(10)
+  })
+})

--- a/src/helpers/heatmap.js
+++ b/src/helpers/heatmap.js
@@ -51,3 +51,35 @@ export const useGetColor = (opacity = 1) => {
 
 export const withoutPrefix = label =>
   label ? label.replace(/.+_(\d+?\.?(\d+)?|\+[Ii]nf)$/, "$1") : label
+
+export const cropHeatmapZeroEdges = (ids, isZeroOnly, minVisible = 5) => {
+  if (!Array.isArray(ids) || typeof isZeroOnly !== "function" || ids.length <= minVisible)
+    return ids
+
+  const zeroOnly = ids.map(isZeroOnly)
+  const firstNonZero = zeroOnly.findIndex(isZero => !isZero)
+
+  if (firstNonZero === -1) return ids
+
+  let lastNonZero = zeroOnly.length - 1
+  while (lastNonZero >= 0 && zeroOnly[lastNonZero]) lastNonZero--
+
+  let first = firstNonZero > 0 ? firstNonZero - 1 : firstNonZero
+  let last = lastNonZero < ids.length - 1 ? lastNonZero + 1 : lastNonZero
+  const targetLength = Math.min(minVisible, ids.length)
+
+  while (last - first + 1 < targetLength) {
+    const bottomDistance = firstNonZero - first
+    const topDistance = last - lastNonZero
+
+    if (first > 0 && (last === ids.length - 1 || bottomDistance <= topDistance)) {
+      first--
+    } else if (last < ids.length - 1) {
+      last++
+    } else {
+      break
+    }
+  }
+
+  return ids.slice(first, last + 1)
+}

--- a/src/helpers/heatmap.js
+++ b/src/helpers/heatmap.js
@@ -33,8 +33,13 @@ const getColors = opacity => [
 ]
 
 export const makeGetColor = (chart, opacity = 1) => {
-  const max = chart.getAttribute("max")
+  const max = Number(chart.getAttribute("max"))
   const colors = getColors(opacity)
+
+  if (!Number.isFinite(max) || max <= 0) {
+    return value => (value == null ? "transparent" : colors[0])
+  }
+
   const step = max / (colors.length - 1)
   const getLinearColor = scaleLinear()
     .domain(Array.from({ length: colors.length - 1 }, (_, i) => i * step))

--- a/src/helpers/heatmap.test.js
+++ b/src/helpers/heatmap.test.js
@@ -5,6 +5,7 @@ import {
   heatmapOrChartType,
   makeGetColor,
   withoutPrefix,
+  cropHeatmapZeroEdges,
 } from "./heatmap"
 
 describe("heatmap utilities", () => {
@@ -162,6 +163,76 @@ describe("heatmap utilities", () => {
 
     it("handles empty string", () => {
       expect(withoutPrefix("")).toBe("")
+    })
+  })
+
+  describe("cropHeatmapZeroEdges", () => {
+    const makeIsZeroOnly = zeroIds => id => zeroIds.includes(id)
+
+    it("crops only zero buckets from the bottom and top edges", () => {
+      const ids = ["0", "1", "2", "3", "4", "5", "6"]
+
+      expect(cropHeatmapZeroEdges(ids, makeIsZeroOnly(["0", "1", "6"]))).toEqual([
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+      ])
+    })
+
+    it("keeps interior zero buckets", () => {
+      const ids = ["0", "1", "2", "3", "4", "5", "6", "7", "8"]
+
+      expect(cropHeatmapZeroEdges(ids, makeIsZeroOnly(["0", "1", "3", "7", "8"]))).toEqual([
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+      ])
+    })
+
+    it("keeps one zero bucket below and above a five-bucket non-zero span", () => {
+      const ids = ["0", "1", "2", "3", "4", "5", "6", "7", "8"]
+
+      expect(cropHeatmapZeroEdges(ids, makeIsZeroOnly(["0", "1", "7", "8"]))).toEqual([
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+      ])
+    })
+
+    it("expands around a narrow non-zero range to keep at least five buckets", () => {
+      const ids = ["0", "1", "2", "3", "4", "5", "6", "7", "8"]
+      const zeroIds = ["0", "1", "2", "4", "5", "6", "7", "8"]
+
+      expect(cropHeatmapZeroEdges(ids, makeIsZeroOnly(zeroIds))).toEqual(["1", "2", "3", "4", "5"])
+    })
+
+    it("keeps the full scale when all buckets are zero", () => {
+      const ids = ["0", "1", "2", "3", "4", "5", "6"]
+
+      expect(cropHeatmapZeroEdges(ids, makeIsZeroOnly(ids))).toEqual(ids)
+    })
+
+    it("does not crop when there are fewer than the minimum visible buckets", () => {
+      const ids = ["0", "1", "2"]
+
+      expect(cropHeatmapZeroEdges(ids, makeIsZeroOnly(["0", "2"]))).toEqual(ids)
+    })
+
+    it("does not crop without a zero-only predicate", () => {
+      const ids = ["0", "1", "2", "3", "4", "5"]
+
+      expect(cropHeatmapZeroEdges(ids)).toEqual(ids)
     })
   })
 })

--- a/src/helpers/heatmap.test.js
+++ b/src/helpers/heatmap.test.js
@@ -130,6 +130,16 @@ describe("heatmap utilities", () => {
       expect(getColor(0)).toMatch(/rgb/)
     })
 
+    it("uses the low-end color when the heatmap max is zero", () => {
+      mockChart.getAttribute = jest.fn(() => 0)
+
+      const getColor = makeGetColor(mockChart)
+
+      expect(getColor(0)).toBe("rgba(62, 73, 137, 1)")
+      expect(getColor(null)).toBe("transparent")
+      expect(getColor(undefined)).toBe("transparent")
+    })
+
     it("returns color for valid values", () => {
       const getColor = makeGetColor(mockChart)
       const color = getColor(100)

--- a/src/helpers/heatmapScale.js
+++ b/src/helpers/heatmapScale.js
@@ -1,0 +1,94 @@
+import scalableUnits, { keys as scalableUnitKeys } from "@/helpers/units/scalableUnits"
+
+const heatmapValueRegex = /^\d*\.?\d+$/
+const heatmapInfRegex = /^\+inf$/i
+const heatmapPrefixRegex = /^.+_(\d*\.?\d+|\+[Ii]nf)$/
+
+const getHeatmapValueLabel = value => {
+  if (typeof value !== "string") return value
+
+  return value.match(heatmapPrefixRegex)?.[1] || value
+}
+
+export const parseHeatmapValue = value => {
+  const label = getHeatmapValueLabel(value)
+
+  if (typeof label !== "string") return NaN
+  if (heatmapInfRegex.test(label)) return Infinity
+  if (!heatmapValueRegex.test(label)) return NaN
+
+  return parseFloat(label)
+}
+
+export const isHeatmapNumeric = values =>
+  values.every(value => !isNaN(parseHeatmapValue(value)))
+
+export const isHeatmapBinary = values => {
+  let hasBinaryCandidate = false
+
+  return values.every(value => {
+    const parsed = parseHeatmapValue(value)
+
+    if (!isFinite(parsed) || parsed <= 1) return true
+
+    hasBinaryCandidate = true
+
+    return Number.isInteger(parsed) && parsed > 0 && Number.isInteger(Math.log2(parsed))
+  }) && hasBinaryCandidate
+}
+
+export const detectHeatmapScale = values => {
+  if (!values.length || !isHeatmapNumeric(values)) return null
+
+  return isHeatmapBinary(values) ? "binary" : "num"
+}
+
+export const sortHeatmapValues = values => {
+  if (!isHeatmapNumeric(values)) return null
+
+  return values
+    .map((value, index) => ({ value, index, parsed: parseHeatmapValue(value) }))
+    .sort((a, b) => a.parsed - b.parsed || a.index - b.index)
+    .map(({ value }) => value)
+}
+
+const getScaleEntries = scale =>
+  (scalableUnitKeys[scale] || []).map(prefix => ({
+    prefix: prefix === "1" ? "" : prefix,
+    divider: prefix === "1" ? 1 : scalableUnits[scale][prefix],
+  }))
+
+const formatNumber = value => {
+  if (value > 0 && value < 0.01) return parseFloat(value.toPrecision(3)).toString()
+
+  return parseFloat(value.toFixed(2)).toString()
+}
+
+export const formatScaledValue = (value, scale) => {
+  if (!value) return "0"
+
+  const entries = getScaleEntries(scale)
+  const entry = entries.reduce(
+    (selected, candidate) =>
+      candidate.divider <= value && candidate.divider > selected.divider ? candidate : selected,
+    { prefix: "", divider: 0 }
+  )
+
+  if (!entry.divider) return formatNumber(value)
+
+  return `${formatNumber(value / entry.divider)}${entry.prefix}`
+}
+
+export const formatHeatmapLabel = (value, scale) => {
+  const label = getHeatmapValueLabel(value)
+
+  if (typeof label !== "string") return value
+  if (heatmapInfRegex.test(label)) return "+Inf"
+  if (!scale) return label
+
+  const parsed = parseHeatmapValue(label)
+
+  if (isNaN(parsed)) return label
+
+  return formatScaledValue(parsed, scale)
+}

--- a/src/helpers/heatmapScale.test.js
+++ b/src/helpers/heatmapScale.test.js
@@ -1,0 +1,174 @@
+import {
+  detectHeatmapScale,
+  formatHeatmapLabel,
+  formatScaledValue,
+  isHeatmapBinary,
+  isHeatmapNumeric,
+  parseHeatmapValue,
+  sortHeatmapValues,
+} from "./heatmapScale"
+
+describe("heatmapScale", () => {
+  describe("parseHeatmapValue", () => {
+    it("parses integer and decimal bucket labels", () => {
+      expect(parseHeatmapValue("0")).toBe(0)
+      expect(parseHeatmapValue("5")).toBe(5)
+      expect(parseHeatmapValue("10000")).toBe(10000)
+      expect(parseHeatmapValue("0.005")).toBe(0.005)
+      expect(parseHeatmapValue("2.5")).toBe(2.5)
+      expect(parseHeatmapValue(".5")).toBe(0.5)
+    })
+
+    it("parses prefixed bucket labels", () => {
+      expect(parseHeatmapValue("bucket_1")).toBe(1)
+      expect(parseHeatmapValue("latency_0.005")).toBe(0.005)
+      expect(parseHeatmapValue("bucket_+Inf")).toBe(Infinity)
+    })
+
+    it("parses positive infinity variants", () => {
+      expect(parseHeatmapValue("+Inf")).toBe(Infinity)
+      expect(parseHeatmapValue("+inf")).toBe(Infinity)
+      expect(parseHeatmapValue("+INF")).toBe(Infinity)
+    })
+
+    it("rejects non-bucket labels", () => {
+      const rejected = ["5.", "-Inf", "Inf", "5ms", "5e3", "0x10", "abc", "", null, undefined, " "]
+
+      rejected.forEach(value => expect(parseHeatmapValue(value)).toBeNaN())
+    })
+  })
+
+  describe("isHeatmapNumeric", () => {
+    it("accepts pure numeric and infinity labels", () => {
+      expect(isHeatmapNumeric(["0.005", "0.01", "+Inf"])).toBe(true)
+      expect(isHeatmapNumeric(["1", "2", "5", "10", "+Inf"])).toBe(true)
+      expect(isHeatmapNumeric(["bucket_1", "bucket_2", "bucket_+Inf"])).toBe(true)
+      expect(isHeatmapNumeric(["+Inf"])).toBe(true)
+      expect(isHeatmapNumeric([])).toBe(true)
+    })
+
+    it("rejects mixed non-numeric labels", () => {
+      expect(isHeatmapNumeric(["5ms", "1", "+Inf"])).toBe(false)
+    })
+  })
+
+  describe("isHeatmapBinary", () => {
+    it("detects integer powers of two above one", () => {
+      expect(isHeatmapBinary(["1024", "2048", "4096", "+Inf"])).toBe(true)
+      expect(isHeatmapBinary(["1", "2", "4", "8"])).toBe(true)
+      expect(isHeatmapBinary(["0.25", "0.5", "1", "2", "4"])).toBe(true)
+    })
+
+    it("rejects non-powers of two and empty candidate sets", () => {
+      expect(isHeatmapBinary(["0", "5", "10"])).toBe(false)
+      expect(isHeatmapBinary(["1000", "2000"])).toBe(false)
+      expect(isHeatmapBinary(["3", "5", "+Inf"])).toBe(false)
+      expect(isHeatmapBinary(["0.25", "0.5", "1", "+Inf"])).toBe(false)
+    })
+
+    it("handles powers larger than 32-bit integers", () => {
+      expect(isHeatmapBinary(["4294967296", "1099511627776"])).toBe(true)
+    })
+  })
+
+  describe("detectHeatmapScale", () => {
+    it("selects binary only for power-of-two bucket sets", () => {
+      expect(detectHeatmapScale(["1024", "2048", "+Inf"])).toBe("binary")
+    })
+
+    it("selects SI for numeric non-binary bucket sets", () => {
+      expect(detectHeatmapScale(["0.005", "0.01", "+Inf"])).toBe("num")
+      expect(detectHeatmapScale(["0", "5", "10", "+Inf"])).toBe("num")
+    })
+
+    it("returns null for non-numeric or empty bucket sets", () => {
+      expect(detectHeatmapScale(["5ms", "1"])).toBe(null)
+      expect(detectHeatmapScale([])).toBe(null)
+    })
+  })
+
+  describe("sortHeatmapValues", () => {
+    it("sorts numeric labels with positive infinity last", () => {
+      expect(sortHeatmapValues(["5", "1", "10", "+Inf"])).toEqual(["1", "5", "10", "+Inf"])
+      expect(sortHeatmapValues(["10", "+Inf", "1", "5"])).toEqual(["1", "5", "10", "+Inf"])
+      expect(sortHeatmapValues(["0.25", "0.005", "1", "+Inf"])).toEqual([
+        "0.005",
+        "0.25",
+        "1",
+        "+Inf",
+      ])
+    })
+
+    it("sorts the live Prometheus bucket shape", () => {
+      expect(sortHeatmapValues(["+Inf", "0.3", "10", "120", "15", "2", "2.5"])).toEqual([
+        "0.3",
+        "2",
+        "2.5",
+        "10",
+        "15",
+        "120",
+        "+Inf",
+      ])
+    })
+
+    it("sorts prefixed compatibility labels while preserving original ids", () => {
+      expect(sortHeatmapValues(["bucket_+Inf", "bucket_10", "bucket_2"])).toEqual([
+        "bucket_2",
+        "bucket_10",
+        "bucket_+Inf",
+      ])
+    })
+
+    it("falls back for non-numeric labels and does not mutate input", () => {
+      const values = ["10", "1", "+Inf"]
+      const sorted = sortHeatmapValues(values)
+
+      expect(sorted).toEqual(["1", "10", "+Inf"])
+      expect(sorted).not.toBe(values)
+      expect(values).toEqual(["10", "1", "+Inf"])
+      expect(sortHeatmapValues(["5ms", "1"])).toBe(null)
+    })
+  })
+
+  describe("formatScaledValue", () => {
+    it("formats SI values compactly", () => {
+      expect(formatScaledValue(0.005, "num")).toBe("5m")
+      expect(formatScaledValue(0.0001, "num")).toBe("100u")
+      expect(formatScaledValue(500, "num")).toBe("500")
+      expect(formatScaledValue(1000, "num")).toBe("1k")
+      expect(formatScaledValue(1500, "num")).toBe("1.5k")
+      expect(formatScaledValue(1250, "num")).toBe("1.25k")
+      expect(formatScaledValue(1000000, "num")).toBe("1M")
+      expect(formatScaledValue(0, "num")).toBe("0")
+    })
+
+    it("formats binary values compactly", () => {
+      expect(formatScaledValue(500, "binary")).toBe("500")
+      expect(formatScaledValue(1023, "binary")).toBe("1023")
+      expect(formatScaledValue(1024, "binary")).toBe("1Ki")
+      expect(formatScaledValue(1536, "binary")).toBe("1.5Ki")
+      expect(formatScaledValue(1048576, "binary")).toBe("1Mi")
+      expect(formatScaledValue(0, "binary")).toBe("0")
+    })
+  })
+
+  describe("formatHeatmapLabel", () => {
+    it("keeps infinity literal", () => {
+      expect(formatHeatmapLabel("+Inf", "num")).toBe("+Inf")
+      expect(formatHeatmapLabel("+Inf", "binary")).toBe("+Inf")
+      expect(formatHeatmapLabel("+Inf", null)).toBe("+Inf")
+      expect(formatHeatmapLabel("+inf", "num")).toBe("+Inf")
+    })
+
+    it("formats numeric labels using the detected scale", () => {
+      expect(formatHeatmapLabel("0.005", "num")).toBe("5m")
+      expect(formatHeatmapLabel("1024", "binary")).toBe("1Ki")
+      expect(formatHeatmapLabel("bucket_1024", "binary")).toBe("1Ki")
+    })
+
+    it("passes through fallback labels", () => {
+      expect(formatHeatmapLabel("5ms", "num")).toBe("5ms")
+      expect(formatHeatmapLabel("0.005", null)).toBe("0.005")
+    })
+  })
+})

--- a/src/sdk/initialAttributes.js
+++ b/src/sdk/initialAttributes.js
@@ -274,6 +274,7 @@ export default {
 
   renderedAt: null,
   fetchAt: null,
+  liveAnchor: null,
 
   dimensionsOnNonDimensionGrouping: null,
 

--- a/src/sdk/makeChart/api/helpers.js
+++ b/src/sdk/makeChart/api/helpers.js
@@ -8,14 +8,18 @@ export const getChartURLOptions = chart => {
     eliminateZeroDimensions,
     urlOptions = [],
     chartLibrary,
+    chartType,
+    selectedChartType,
     nulls2zero,
   } = chart.getAttributes()
   const opts = defaultUrlOptionsByLibrary[chartLibrary] || defaultUrlOptionsByLibrary.default
+  const effectiveChartType = selectedChartType || chartType
+  const canEliminateZeroDimensions = chartLibrary !== "table" && effectiveChartType !== "heatmap"
 
   return [
     ...urlOptions,
     "jsonwrap",
-    chartLibrary !== "table" && eliminateZeroDimensions && "nonzero",
+    canEliminateZeroDimensions && eliminateZeroDimensions && "nonzero",
     nulls2zero && "null2zero",
     "flip",
     "ms",

--- a/src/sdk/makeChart/api/helpers.js
+++ b/src/sdk/makeChart/api/helpers.js
@@ -33,6 +33,19 @@ export const pointMultiplierByChartType = {
   default: 0.7,
 }
 
+export const getLiveFetchBefore = ({
+  after,
+  renderedAt,
+  hovering,
+  fetchStartedAt,
+  viewUpdateEvery,
+}) => {
+  if (after > 0) return null
+  if (viewUpdateEvery && viewUpdateEvery > Math.abs(after)) return null
+
+  return hovering && renderedAt ? Math.ceil(renderedAt / 1000) : Math.ceil(fetchStartedAt / 1000)
+}
+
 export const getChartPayload = (chart, attrs = {}) => {
   const ui = chart.getUI()
   const width = chart.getAttribute("containerWidth", ui.getChartWidth())
@@ -57,20 +70,25 @@ export const getChartPayload = (chart, attrs = {}) => {
     pointMultiplierByChartType[chartLibrary] ||
     pointMultiplierByChartType.default
 
-  const fetchOn =
-    hovering && renderedAt ? Math.ceil(renderedAt / 1000) : Math.ceil(fetchStartedAt / 1000)
+  const fetchBefore = getLiveFetchBefore({
+    after,
+    renderedAt,
+    hovering,
+    fetchStartedAt,
+    viewUpdateEvery,
+  })
 
   const afterBefore =
     after > 0
       ? { after, before }
-      : viewUpdateEvery && viewUpdateEvery > Math.abs(after)
+      : fetchBefore === null
         ? {
             after,
             before: 0,
           }
         : {
-            after: fetchOn + after,
-            before: fetchOn,
+            after: fetchBefore + after,
+            before: fetchBefore,
           }
 
   const points = customPoints || Math.round((width / pixelsPerPoint) * pointsMultiplier)

--- a/src/sdk/makeChart/api/helpers.js
+++ b/src/sdk/makeChart/api/helpers.js
@@ -4,17 +4,10 @@ const defaultUrlOptionsByLibrary = {
 }
 
 export const getChartURLOptions = chart => {
-  const {
-    eliminateZeroDimensions,
-    urlOptions = [],
-    chartLibrary,
-    chartType,
-    selectedChartType,
-    nulls2zero,
-  } = chart.getAttributes()
+  const { eliminateZeroDimensions, urlOptions = [], chartLibrary, chartType, nulls2zero } =
+    chart.getAttributes()
   const opts = defaultUrlOptionsByLibrary[chartLibrary] || defaultUrlOptionsByLibrary.default
-  const effectiveChartType = selectedChartType || chartType
-  const canEliminateZeroDimensions = chartLibrary !== "table" && effectiveChartType !== "heatmap"
+  const canEliminateZeroDimensions = chartLibrary !== "table" && chartType !== "heatmap"
 
   return [
     ...urlOptions,

--- a/src/sdk/makeChart/api/helpers.test.js
+++ b/src/sdk/makeChart/api/helpers.test.js
@@ -1,6 +1,7 @@
 import {
   getChartURLOptions,
   pointMultiplierByChartType,
+  getLiveFetchBefore,
   getChartPayload,
   errorCodesToMessage,
 } from "./helpers"
@@ -104,6 +105,56 @@ describe("API helpers", () => {
     })
   })
 
+  describe("getLiveFetchBefore", () => {
+    it("rounds the live request anchor from fetchStartedAt", () => {
+      const result = getLiveFetchBefore({
+        after: -300,
+        renderedAt: null,
+        hovering: false,
+        fetchStartedAt: 1000500,
+        viewUpdateEvery: 0,
+      })
+
+      expect(result).toBe(1001)
+    })
+
+    it("uses renderedAt when the chart is hovering", () => {
+      const result = getLiveFetchBefore({
+        after: -300,
+        renderedAt: 1000000,
+        hovering: true,
+        fetchStartedAt: 1001500,
+        viewUpdateEvery: 0,
+      })
+
+      expect(result).toBe(1000)
+    })
+
+    it("does not anchor absolute windows", () => {
+      const result = getLiveFetchBefore({
+        after: 1000,
+        renderedAt: null,
+        hovering: false,
+        fetchStartedAt: 1000500,
+        viewUpdateEvery: 0,
+      })
+
+      expect(result).toBe(null)
+    })
+
+    it("does not anchor view update windows kept relative for the API", () => {
+      const result = getLiveFetchBefore({
+        after: -300,
+        renderedAt: null,
+        hovering: false,
+        fetchStartedAt: 1000500,
+        viewUpdateEvery: 600,
+      })
+
+      expect(result).toBe(null)
+    })
+  })
+
   describe("getChartPayload", () => {
     it("returns correct payload structure", () => {
       const { chart } = makeTestChart({
@@ -199,6 +250,30 @@ describe("API helpers", () => {
 
       expect(result.after).toBe(1000)
       expect(result.before).toBe(2000)
+    })
+
+    it("uses the same live request anchor as getLiveFetchBefore", () => {
+      const { chart } = makeTestChart({
+        attributes: {
+          after: -300,
+          before: 0,
+          groupingMethod: "average",
+          groupingTime: "auto",
+          renderedAt: null,
+          hovering: false,
+          fetchStartedAt: 1000500,
+          chartType: "line",
+          pixelsPerPoint: 4,
+          chartLibrary: "dygraph",
+        },
+      })
+
+      chart.getUI().getChartWidth = () => 800
+
+      const result = getChartPayload(chart)
+
+      expect(result.after).toBe(701)
+      expect(result.before).toBe(1001)
     })
 
     it("uses different multiplier for multiBar", () => {

--- a/src/sdk/makeChart/api/helpers.test.js
+++ b/src/sdk/makeChart/api/helpers.test.js
@@ -65,6 +65,37 @@ describe("API helpers", () => {
       expect(result).not.toContain("nonzero")
     })
 
+    it("excludes nonzero for heatmap chart type", () => {
+      const { chart } = makeTestChart({
+        attributes: {
+          eliminateZeroDimensions: true,
+          urlOptions: [],
+          chartLibrary: "dygraph",
+          chartType: "heatmap",
+        },
+      })
+
+      const result = getChartURLOptions(chart)
+
+      expect(result).not.toContain("nonzero")
+    })
+
+    it("excludes nonzero for selected heatmap chart type", () => {
+      const { chart } = makeTestChart({
+        attributes: {
+          eliminateZeroDimensions: true,
+          urlOptions: [],
+          chartLibrary: "dygraph",
+          chartType: "line",
+          selectedChartType: "heatmap",
+        },
+      })
+
+      const result = getChartURLOptions(chart)
+
+      expect(result).not.toContain("nonzero")
+    })
+
     it("includes group-by-labels for groupBoxes library", () => {
       const { chart } = makeTestChart({
         attributes: {

--- a/src/sdk/makeChart/api/helpers.test.js
+++ b/src/sdk/makeChart/api/helpers.test.js
@@ -80,22 +80,6 @@ describe("API helpers", () => {
       expect(result).not.toContain("nonzero")
     })
 
-    it("excludes nonzero for selected heatmap chart type", () => {
-      const { chart } = makeTestChart({
-        attributes: {
-          eliminateZeroDimensions: true,
-          urlOptions: [],
-          chartLibrary: "dygraph",
-          chartType: "line",
-          selectedChartType: "heatmap",
-        },
-      })
-
-      const result = getChartURLOptions(chart)
-
-      expect(result).not.toContain("nonzero")
-    })
-
     it("includes group-by-labels for groupBoxes library", () => {
       const { chart } = makeTestChart({
         attributes: {

--- a/src/sdk/makeChart/filters/makeControllers.js
+++ b/src/sdk/makeChart/filters/makeControllers.js
@@ -126,7 +126,6 @@ export default chart => {
     if (!chartLibraries[selected]) {
       chart.updateAttributes({
         chartLibrary: "dygraph",
-        selectedChartType: selected,
         chartType: selected,
         processing: true,
       })

--- a/src/sdk/makeChart/index.js
+++ b/src/sdk/makeChart/index.js
@@ -67,16 +67,24 @@ export default ({
   let cachedDateWindow = null
   let prevAfter = null
   let prevRenderedAt = null
+  let prevLiveAnchor = null
   let prevNow = null
   node.getDateWindow = () => {
-    const { after, before, renderedAt } = node.getAttributes()
+    const { after, before, renderedAt, liveAnchor } = node.getAttributes()
     const now = sdk.getRoot().getAttribute("fetchAt", Date.now())
+    const anchor = liveAnchor ?? now
 
-    if (prevAfter === after && prevRenderedAt === renderedAt && prevNow === now)
+    if (
+      prevAfter === after &&
+      prevRenderedAt === renderedAt &&
+      prevLiveAnchor === liveAnchor &&
+      prevNow === now
+    )
       return cachedDateWindow
 
     prevAfter = after
     prevRenderedAt = renderedAt
+    prevLiveAnchor = liveAnchor
     prevNow = now
 
     cachedDateWindow =
@@ -84,7 +92,7 @@ export default ({
         ? [after * 1000, before * 1000]
         : renderedAt
           ? [renderedAt + after * 1000, renderedAt]
-          : [now + after * 1000, now]
+          : [anchor + after * 1000, anchor]
 
     return cachedDateWindow
   }

--- a/src/sdk/makeChart/index.test.js
+++ b/src/sdk/makeChart/index.test.js
@@ -1,4 +1,3 @@
-import makeChart from "./index"
 import { makeTestChart } from "@jest/testUtilities"
 
 describe("makeChart", () => {
@@ -70,6 +69,22 @@ describe("makeChart", () => {
 
     const result = chart.getUpdateEvery()
     expect(result).toBe(0)
+  })
+
+  it("keeps live relative date window anchored between payload updates", () => {
+    chart.updateAttributes({
+      after: -300,
+      before: 0,
+      renderedAt: null,
+      liveAnchor: 1000000,
+    })
+    sdk.getRoot().setAttribute("fetchAt", 1000500)
+
+    expect(chart.getDateWindow()).toEqual([700000, 1000000])
+
+    sdk.getRoot().setAttribute("fetchAt", 1001500)
+
+    expect(chart.getDateWindow()).toEqual([700000, 1000000])
   })
 
   it("getThemeIndex returns correct index for theme", () => {

--- a/src/sdk/makeChart/makeDataFetch.js
+++ b/src/sdk/makeChart/makeDataFetch.js
@@ -1,4 +1,5 @@
 import { errorCodesToMessage } from "./api"
+import { getLiveFetchBefore } from "./api/helpers"
 import makeGetClosestRow from "./makeGetClosestRow"
 import getInitialFilterAttributes from "./filters/getInitialAttributes"
 import camelizePayload from "./camelizePayload"
@@ -8,6 +9,13 @@ const initialPayload = {
   data: [],
   all: [],
   tree: {},
+}
+
+const getLiveAnchor = payload => {
+  const lastRow = payload?.data?.[payload.data.length - 1]
+  const lastTimestamp = lastRow?.[0]
+
+  return typeof lastTimestamp === "number" && isFinite(lastTimestamp) ? lastTimestamp : null
 }
 
 export default chart => {
@@ -88,7 +96,7 @@ export default chart => {
     return data?.length || 0
   }
 
-  chart.doneFetch = nextRawPayload => {
+  chart.doneFetch = (nextRawPayload, { liveAnchor } = {}) => {
     chart.backoffMs = 0
 
     setTimeout(() => {
@@ -118,6 +126,7 @@ export default chart => {
         loaded: true,
         loading: false,
         processing: false,
+        liveAnchor: liveAnchor ?? getLiveAnchor(nextPayload),
         updatedAt: Date.now(),
         outOfLimits: !dataLength,
         ...restPayload,
@@ -233,11 +242,25 @@ export default chart => {
       return Promise.resolve()
     }
 
+    const fetchStartedAt = Date.now()
+
     chart.updateAttributes({
       processing,
       loading: true,
-      fetchStartedAt: Date.now(),
+      fetchStartedAt,
     })
+    const { after, hovering, renderedAt, viewUpdateEvery } = chart.getAttributes()
+    const fetchBefore = getLiveFetchBefore({
+      after,
+      hovering,
+      renderedAt,
+      fetchStartedAt,
+      viewUpdateEvery,
+    })
+    const liveAnchor =
+      typeof fetchBefore === "number" && isFinite(fetchBefore) && fetchBefore > 0
+        ? fetchBefore * 1000
+        : null
 
     chart.cancelFetch()
     chart.trigger("startFetch")
@@ -249,7 +272,7 @@ export default chart => {
     abortController = new AbortController()
 
     return chart.baseFetch({
-      doneFetch: chart.doneFetch,
+      doneFetch: data => chart.doneFetch(data, { liveAnchor }),
       failFetch: chart.failFetch,
       signal: abortController.signal,
     })

--- a/src/sdk/makeChart/makeDataFetch.js
+++ b/src/sdk/makeChart/makeDataFetch.js
@@ -118,7 +118,7 @@ export default chart => {
       const attributes = chart.getAttributes()
 
       chart.setAttributes({
-        chartType: attributes.selectedChartType || attributes.chartType || chartType,
+        chartType: attributes.chartType || chartType,
         title: attributes.title === null ? title : attributes.title,
       })
 

--- a/src/sdk/makeChart/makeDataFetch.test.js
+++ b/src/sdk/makeChart/makeDataFetch.test.js
@@ -1,24 +1,47 @@
 import makeDataFetch from "./makeDataFetch"
+import { makeTestChart } from "@jest/testUtilities"
+import makeDefaultSDK from "@/makeDefaultSDK"
+
+const rawPayload = {
+  result: {
+    data: [
+      [1000, [10]],
+      [2000, [20]],
+    ],
+    labels: ["time", "value"],
+    point: {
+      value: 0,
+    },
+  },
+}
 
 describe("makeDataFetch", () => {
   let mockChart
 
   beforeEach(() => {
+    const attributes = {
+      after: -300,
+      before: 0,
+      firstEntry: 1000000,
+      selectedChartType: null,
+      chartType: "line",
+      title: null,
+      loaded: false,
+      initializedFilters: true,
+    }
+
     mockChart = {
-      getAttribute: jest.fn(),
-      getAttributes: jest.fn(() => ({
-        after: -300,
-        before: 0,
-        firstEntry: 1000000,
-        selectedChartType: null,
-        chartType: "line",
-        title: null,
-        loaded: false,
-        initializedFilters: false,
-      })),
-      updateAttribute: jest.fn(),
-      updateAttributes: jest.fn(),
-      setAttributes: jest.fn(),
+      getAttribute: jest.fn((name, fallback) => attributes[name] ?? fallback),
+      getAttributes: jest.fn(() => attributes),
+      updateAttribute: jest.fn((name, value) => {
+        attributes[name] = value
+      }),
+      updateAttributes: jest.fn(nextAttributes => {
+        Object.assign(attributes, nextAttributes)
+      }),
+      setAttributes: jest.fn(nextAttributes => {
+        Object.assign(attributes, nextAttributes)
+      }),
       trigger: jest.fn(),
       on: jest.fn(),
       getParent: jest.fn(() => ({
@@ -27,21 +50,13 @@ describe("makeDataFetch", () => {
       getRoot: jest.fn(() => ({
         trigger: jest.fn(),
       })),
-      getChart: jest.fn(() =>
-        Promise.resolve({
-          result: {
-            data: [
-              [1000, 10],
-              [2000, 20],
-            ],
-          },
-        })
-      ),
+      getChart: jest.fn(() => Promise.resolve(rawPayload)),
       updateDimensions: jest.fn(),
       startAutofetch: jest.fn(),
       backoff: jest.fn(),
       invalidateClosestRowCache: jest.fn(),
       getFilteredNodeIds: jest.fn(() => []),
+      getUnits: jest.fn(() => "value"),
     }
 
     global.Date.now = jest.fn(() => 1000000000)
@@ -152,5 +167,64 @@ describe("makeDataFetch", () => {
     mockChart.fetch()
 
     expect(mockChart.trigger).toHaveBeenCalledWith("startFetch")
+  })
+
+  it("stores the live request anchor after a successful fetch", async () => {
+    global.Date.now.mockReturnValue(1000500)
+    const { chart } = makeTestChart({
+      attributes: {
+        after: -300,
+        before: 0,
+        renderedAt: null,
+        hovering: false,
+        viewUpdateEvery: 0,
+      },
+    })
+
+    await chart.fetch()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(chart.getAttribute("liveAnchor")).toBe(1001000)
+    expect(chart.getDateWindow()).toEqual([701000, 1001000])
+  })
+
+  it("keeps the live request anchor bound to its own fetch response", async () => {
+    const resolves = []
+    const getChart = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolves.push(resolve)
+        })
+    )
+    const sdk = makeDefaultSDK({
+      attributes: {
+        after: -300,
+        before: 0,
+        renderedAt: null,
+        hovering: false,
+        viewUpdateEvery: 0,
+      },
+    })
+    const chart = sdk.makeChart({ getChart })
+    sdk.appendChild(chart)
+
+    global.Date.now.mockReturnValue(1000500)
+    const firstFetch = chart.fetch()
+    resolves[0](rawPayload)
+    await firstFetch
+
+    chart.updateAttribute("selectedDimensions", ["value"])
+    global.Date.now.mockReturnValue(1001500)
+    const secondFetch = chart.fetch()
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(chart.getAttribute("liveAnchor")).toBe(1001000)
+
+    resolves[1](rawPayload)
+    await secondFetch
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(chart.getAttribute("liveAnchor")).toBe(1002000)
   })
 })

--- a/src/sdk/makeChart/makeDataFetch.test.js
+++ b/src/sdk/makeChart/makeDataFetch.test.js
@@ -23,7 +23,6 @@ describe("makeDataFetch", () => {
       after: -300,
       before: 0,
       firstEntry: 1000000,
-      selectedChartType: null,
       chartType: "line",
       title: null,
       loaded: false,

--- a/src/sdk/makeChart/makeDimensions.js
+++ b/src/sdk/makeChart/makeDimensions.js
@@ -7,7 +7,7 @@ import {
   isIncremental,
   withoutPrefix,
 } from "@/helpers/heatmap"
-import { detectHeatmapScale, sortHeatmapValues } from "@/helpers/heatmapScale"
+import { detectHeatmapScale, formatHeatmapLabel, sortHeatmapValues } from "@/helpers/heatmapScale"
 import groupBy from "lodash/groupBy"
 import isEmpty from "lodash/isEmpty"
 
@@ -144,13 +144,13 @@ export default (chart, sdk) => {
 
   const updateVisibleDimensions = () => {
     const selectedLegendDimensions = chart.getAttribute("selectedLegendDimensions")
+    const matchesSelectedLegendDimension = id =>
+      selectedLegendDimensions.includes(id) ||
+      selectedLegendDimensions.includes(chart.getDimensionName(id)) ||
+      (isHeatmap(chart) && selectedLegendDimensions.includes(withoutPrefix(id)))
 
     visibleDimensionIds = selectedLegendDimensions.length
-      ? sortedDimensionIds.filter(
-          id =>
-            selectedLegendDimensions.includes(id) ||
-            selectedLegendDimensions.includes(chart.getDimensionName(id))
-        )
+      ? sortedDimensionIds.filter(matchesSelectedLegendDimension)
       : sortedDimensionIds
 
     const prevDimensionSet = visibleDimensionSet
@@ -173,9 +173,10 @@ export default (chart, sdk) => {
   }
 
   chart.onHoverSortDimensions = (x, dimensionsSort = chart.getAttribute("dimensionsSort")) => {
-    const sort = isHeatmap(chart)
-      ? bySortMethod.default
-      : bySortMethod[dimensionsSort] || bySortMethod.default
+    if (isHeatmap(chart)) return [...chart.getVisibleHeatmapIds()]
+
+    const sort = bySortMethod[dimensionsSort] || bySortMethod.default
+
     return sort(() => [...chart.getVisibleDimensionIds()], x)
   }
 
@@ -341,7 +342,7 @@ export default (chart, sdk) => {
 
     if (!isNaN(partIndex)) dimName = dimName.split(",")?.[partIndex] ?? dimName
 
-    if (isHeatmap(chart)) return withoutPrefix(dimName)
+    if (isHeatmap(chart)) return formatHeatmapLabel(withoutPrefix(dimName), heatmapScale)
 
     return dimName
   }

--- a/src/sdk/makeChart/makeDimensions.js
+++ b/src/sdk/makeChart/makeDimensions.js
@@ -1,6 +1,12 @@
 import dimensionColors from "./theme/dimensionColors"
 import deepEqual, { setsAreEqual } from "@/helpers/deepEqual"
-import { heatmapTypes, isHeatmap, isIncremental, withoutPrefix } from "@/helpers/heatmap"
+import {
+  cropHeatmapZeroEdges,
+  heatmapTypes,
+  isHeatmap,
+  isIncremental,
+  withoutPrefix,
+} from "@/helpers/heatmap"
 import { detectHeatmapScale, sortHeatmapValues } from "@/helpers/heatmapScale"
 import groupBy from "lodash/groupBy"
 import isEmpty from "lodash/isEmpty"
@@ -15,6 +21,9 @@ export default (chart, sdk) => {
   let visibleDimensionSet = new Set()
   let heatmapSortedIds = null
   let heatmapScale = null
+  let heatmapVisiblePayload = null
+  let heatmapVisibleKey = null
+  let heatmapVisibleIds = null
   let colorCursor = 0
 
   const sparklineDimensions = ["sum"]
@@ -242,8 +251,34 @@ export default (chart, sdk) => {
 
   chart.getHeatmapSortedIds = () => heatmapSortedIds
 
-  chart.getVisibleHeatmapIds = () =>
+  const getBaseVisibleHeatmapIds = () =>
     heatmapSortedIds ? heatmapSortedIds.filter(id => visibleDimensionSet.has(id)) : visibleDimensionIds
+
+  const isZeroOnlyHeatmapBucket = id => {
+    const { all = [] } = chart.getPayload()
+    if (!all.length) return false
+
+    return all.every(row => {
+      const value = chart.getRowDimensionValue(id, row, { allowNull: true })
+      return value === null || value === 0
+    })
+  }
+
+  chart.getVisibleHeatmapIds = () => {
+    const ids = getBaseVisibleHeatmapIds()
+    if (!isHeatmap(chart)) return ids
+
+    const payload = chart.getPayload()
+    const key = ids.join("\u0000")
+
+    if (payload === heatmapVisiblePayload && key === heatmapVisibleKey) return heatmapVisibleIds
+
+    heatmapVisiblePayload = payload
+    heatmapVisibleKey = key
+    heatmapVisibleIds = cropHeatmapZeroEdges(ids, isZeroOnlyHeatmapBucket)
+
+    return heatmapVisibleIds
+  }
 
   chart.getHeatmapScale = () => heatmapScale
 
@@ -252,6 +287,7 @@ export default (chart, sdk) => {
     const heatmapIndex = visibleHeatmapIds.findIndex(visibleId => visibleId === id)
 
     if (heatmapIndex !== -1) return heatmapIndex
+    if (isHeatmap(chart)) return -1
 
     const index = chart.getDimensionIndex(id)
 

--- a/src/sdk/makeChart/makeDimensions.js
+++ b/src/sdk/makeChart/makeDimensions.js
@@ -1,6 +1,7 @@
 import dimensionColors from "./theme/dimensionColors"
 import deepEqual, { setsAreEqual } from "@/helpers/deepEqual"
 import { heatmapTypes, isHeatmap, isIncremental, withoutPrefix } from "@/helpers/heatmap"
+import { detectHeatmapScale, sortHeatmapValues } from "@/helpers/heatmapScale"
 import groupBy from "lodash/groupBy"
 import isEmpty from "lodash/isEmpty"
 
@@ -12,6 +13,8 @@ export default (chart, sdk) => {
   let sortedDimensionIds = []
   let visibleDimensionIds = []
   let visibleDimensionSet = new Set()
+  let heatmapSortedIds = null
+  let heatmapScale = null
   let colorCursor = 0
 
   const sparklineDimensions = ["sum"]
@@ -222,6 +225,9 @@ export default (chart, sdk) => {
     else if (/latency/.test(chart.getAttribute("context")))
       chart.setAttribute("heatmapType", heatmapTypes.default)
 
+    heatmapSortedIds = isHeatmap(chart) ? sortHeatmapValues(dimensionIds) : null
+    heatmapScale = isHeatmap(chart) ? detectHeatmapScale(dimensionIds) : null
+
     chart.sortDimensions()
     chart.updateColors()
   }
@@ -233,6 +239,24 @@ export default (chart, sdk) => {
   chart.getVisibleDimensionIds = () => visibleDimensionIds
 
   chart.isDimensionVisible = id => visibleDimensionSet.has(id)
+
+  chart.getHeatmapSortedIds = () => heatmapSortedIds
+
+  chart.getVisibleHeatmapIds = () =>
+    heatmapSortedIds ? heatmapSortedIds.filter(id => visibleDimensionSet.has(id)) : visibleDimensionIds
+
+  chart.getHeatmapScale = () => heatmapScale
+
+  chart.getHeatmapYIndex = id => {
+    const visibleHeatmapIds = chart.getVisibleHeatmapIds()
+    const heatmapIndex = visibleHeatmapIds.findIndex(visibleId => visibleId === id)
+
+    if (heatmapIndex !== -1) return heatmapIndex
+
+    const index = chart.getDimensionIndex(id)
+
+    return index === undefined ? -1 : index
+  }
 
   let memKey = null
   const getMemKey = () => {

--- a/src/sdk/makeChart/makeDimensions.test.js
+++ b/src/sdk/makeChart/makeDimensions.test.js
@@ -1,5 +1,5 @@
 import makeDimensions from "./makeDimensions"
-import { makeTestChart } from "@jest/testUtilities"
+import { loadHeatmapPayload, makeTestChart } from "@jest/testUtilities"
 
 describe("makeDimensions", () => {
   let mockChart
@@ -813,5 +813,71 @@ describe("makeDimensions heatmap bucket ordering", () => {
     expect(chart.getVisibleHeatmapIds()).toEqual(["2", "+Inf"])
     expect(chart.getHeatmapYIndex("2")).toBe(0)
     expect(chart.getHeatmapYIndex("+Inf")).toBe(1)
+  })
+
+  it("crops zero-only buckets from heatmap edges without changing dimension visibility", async () => {
+    const ids = ["0", "1", "2", "3", "4", "5", "6"]
+    const chart = makeHeatmapChart(ids)
+
+    await loadHeatmapPayload(chart, ids, [
+      [0, 0, 1, 0, 2, 0, 0],
+      [0, 0, 0, 0, 2, 0, 0],
+    ])
+
+    expect(chart.getAttribute("chartType")).toBe("heatmap")
+    expect(chart.getHeatmapSortedIds()).toEqual(ids)
+    expect(chart.getDimensionIds()).toEqual(ids)
+    expect(chart.getRowDimensionValue("0", chart.getPayload().all[0])).toBe(0)
+    expect(chart.getRowDimensionValue("2", chart.getPayload().all[0])).toBe(1)
+    expect(chart.getRowDimensionValue("6", chart.getPayload().all[0])).toBe(0)
+    expect(chart.getVisibleHeatmapIds()).toEqual(["1", "2", "3", "4", "5"])
+    expect(chart.getVisibleDimensionIds()).toEqual(ids)
+    expect(chart.getHeatmapYIndex("0")).toBe(-1)
+    expect(chart.getHeatmapYIndex("2")).toBe(1)
+    expect(chart.getHeatmapYIndex("6")).toBe(-1)
+  })
+
+  it("crops incremental heatmap edges using displayed bucket deltas", async () => {
+    const ids = [
+      "bucket_0",
+      "bucket_1",
+      "bucket_2",
+      "bucket_3",
+      "bucket_4",
+      "bucket_5",
+      "bucket_6",
+    ]
+    const chart = makeHeatmapChart(ids)
+
+    await loadHeatmapPayload(chart, ids, [
+      [0, 0, 1, 1, 3, 3, 3],
+      [0, 0, 0, 0, 3, 3, 3],
+    ])
+
+    expect(chart.getAttribute("heatmapType")).toBe("incremental")
+    expect(chart.getVisibleHeatmapIds()).toEqual([
+      "bucket_1",
+      "bucket_2",
+      "bucket_3",
+      "bucket_4",
+      "bucket_5",
+    ])
+    expect(chart.getHeatmapYIndex("bucket_0")).toBe(-1)
+    expect(chart.getHeatmapYIndex("bucket_2")).toBe(1)
+    expect(chart.getHeatmapYIndex("bucket_6")).toBe(-1)
+  })
+
+  it("keeps the full heatmap scale when all buckets are zero", async () => {
+    const ids = ["0", "1", "2", "3", "4", "5", "6"]
+    const chart = makeHeatmapChart(ids)
+
+    await loadHeatmapPayload(chart, ids, [
+      [0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0],
+    ])
+
+    expect(chart.getVisibleHeatmapIds()).toEqual(ids)
+    expect(chart.getHeatmapYIndex("0")).toBe(0)
+    expect(chart.getHeatmapYIndex("6")).toBe(6)
   })
 })

--- a/src/sdk/makeChart/makeDimensions.test.js
+++ b/src/sdk/makeChart/makeDimensions.test.js
@@ -1,5 +1,5 @@
 import makeDimensions from "./makeDimensions"
-import { loadHeatmapPayload, makeTestChart } from "@jest/testUtilities"
+import { loadHeatmapPayload, makeHeatmapPayload, makeTestChart } from "@jest/testUtilities"
 
 describe("makeDimensions", () => {
   let mockChart
@@ -755,6 +755,32 @@ describe("makeDimensions heatmap bucket ordering", () => {
     return chart
   }
 
+  const loadLinePayload = async (chart, ids, rows) => {
+    const payload = makeHeatmapPayload(ids, rows)
+
+    payload.view.chart_type = "line"
+    payload.view.dimensions.grouped_by = []
+
+    chart.doneFetch(payload)
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  const makeLineChart = async (ids, rows, attributes = {}) => {
+    const { chart } = makeTestChart({
+      attributes: {
+        chartType: "line",
+        dimensionsSort: "default",
+        groupBy: [],
+        selectedLegendDimensions: [],
+        ...attributes,
+      },
+    })
+
+    await loadLinePayload(chart, ids, rows)
+
+    return chart
+  }
+
   it("sorts pure numeric Prometheus bucket ids without changing payload index", () => {
     const ids = ["+Inf", "0.3", "10", "120", "15", "2", "2.5"]
     const chart = makeHeatmapChart(ids)
@@ -813,6 +839,15 @@ describe("makeDimensions heatmap bucket ordering", () => {
     expect(chart.getVisibleHeatmapIds()).toEqual(["2", "+Inf"])
     expect(chart.getHeatmapYIndex("2")).toBe(0)
     expect(chart.getHeatmapYIndex("+Inf")).toBe(1)
+  })
+
+  it("keeps prefixed heatmap visibility selection by raw bucket label", () => {
+    const chart = makeHeatmapChart(["bucket_1024", "bucket_2048", "bucket_+Inf"], {
+      selectedLegendDimensions: ["1024"],
+    })
+
+    expect(chart.getDimensionName("bucket_1024")).toBe("1Ki")
+    expect(chart.getVisibleDimensionIds()).toEqual(["bucket_1024"])
   })
 
   it("crops zero-only buckets from heatmap edges without changing dimension visibility", async () => {
@@ -879,5 +914,39 @@ describe("makeDimensions heatmap bucket ordering", () => {
     expect(chart.getVisibleHeatmapIds()).toEqual(ids)
     expect(chart.getHeatmapYIndex("0")).toBe(0)
     expect(chart.getHeatmapYIndex("6")).toBe(6)
+  })
+
+  it("uses cropped y-axis bucket order for heatmap hover popovers", async () => {
+    const ids = ["0", "1", "2", "3", "4", "5", "6"]
+    const chart = makeHeatmapChart(ids)
+
+    await loadHeatmapPayload(chart, ids, [[0, 0, 0, 9, 0, 0, 0]])
+
+    const croppedIds = ["1", "2", "3", "4", "5"]
+
+    expect(chart.getVisibleHeatmapIds()).toEqual(croppedIds)
+
+    const sorted = chart.onHoverSortDimensions(0, "valueDesc")
+
+    expect(sorted).toEqual(croppedIds)
+  })
+
+  it("formats heatmap dimension names with the detected heatmap scale", () => {
+    const siChart = makeHeatmapChart(["0.005", "0.01", "+Inf"])
+    const binaryChart = makeHeatmapChart(["bucket_1024", "bucket_2048", "bucket_+Inf"])
+
+    expect(siChart.getDimensionName("0.005")).toBe("5m")
+    expect(siChart.getDimensionName("+Inf")).toBe("+Inf")
+    expect(binaryChart.getDimensionName("bucket_1024")).toBe("1Ki")
+  })
+
+  it("keeps non-heatmap hover popovers value sorted", async () => {
+    const chart = await makeLineChart(["cpu", "memory", "disk"], [[1, 9, 4]])
+
+    expect(chart.getAttribute("chartType")).toBe("line")
+
+    const sorted = chart.onHoverSortDimensions(0, "valueDesc")
+
+    expect(sorted).toEqual(["memory", "disk", "cpu"])
   })
 })

--- a/src/sdk/makeChart/makeDimensions.test.js
+++ b/src/sdk/makeChart/makeDimensions.test.js
@@ -1,4 +1,5 @@
 import makeDimensions from "./makeDimensions"
+import { makeTestChart } from "@jest/testUtilities"
 
 describe("makeDimensions", () => {
   let mockChart
@@ -660,7 +661,7 @@ describe("makeDimensions", () => {
       mockChart.getRowDimensionValue = jest.fn().mockReturnValueOnce(30).mockReturnValueOnce(10)
 
       const pointData = [1000, 10, 20, 30]
-      const value = mockChart.getRowDimensionValue("disk", pointData, { incrementable: true })
+      mockChart.getRowDimensionValue("disk", pointData, { incrementable: true })
 
       expect(mockChart.getRowDimensionValue).toHaveBeenCalled()
     })
@@ -725,5 +726,92 @@ describe("makeDimensions", () => {
       mockChart.updateDimensions()
       expect(sortDimensionsSpy).toHaveBeenCalled()
     })
+  })
+})
+
+describe("makeDimensions heatmap bucket ordering", () => {
+  const makeHeatmapChart = (ids, attributes = {}) => {
+    const { chart } = makeTestChart({
+      attributes: {
+        chartType: "heatmap",
+        context: "prometheus.test.histogram",
+        dimensionsSort: "default",
+        groupBy: ["dimension"],
+        selectedLegendDimensions: [],
+        viewDimensions: {
+          ids,
+          names: ids,
+          priorities: ids.map((_, index) => index),
+          units: ids.map(() => ""),
+          contexts: ids.map(() => ""),
+          grouped: ["dimension"],
+        },
+        ...attributes,
+      },
+    })
+
+    chart.updateDimensions()
+
+    return chart
+  }
+
+  it("sorts pure numeric Prometheus bucket ids without changing payload index", () => {
+    const ids = ["+Inf", "0.3", "10", "120", "15", "2", "2.5"]
+    const chart = makeHeatmapChart(ids)
+
+    expect(chart.getHeatmapSortedIds()).toEqual(["0.3", "2", "2.5", "10", "15", "120", "+Inf"])
+    expect(chart.getHeatmapScale()).toBe("num")
+    expect(chart.getHeatmapYIndex("0.3")).toBe(0)
+    expect(chart.getHeatmapYIndex("+Inf")).toBe(6)
+
+    expect(chart.getDimensionIndex("+Inf")).toBe(0)
+    expect(chart.getDimensionIndex("2")).toBe(5)
+    expect(chart.getRowDimensionValue("2", [1000, 7, 1, 2, 3, 4, 5, 6])).toBe(5)
+  })
+
+  it("places a runtime-added numeric bucket before +Inf", () => {
+    const chart = makeHeatmapChart(["1", "2", "5", "10", "+Inf"])
+    const nextIds = ["1", "2", "5", "10", "+Inf", "3"]
+
+    chart.setAttribute("viewDimensions", {
+      ids: nextIds,
+      names: nextIds,
+      priorities: nextIds.map((_, index) => index),
+      units: nextIds.map(() => ""),
+      contexts: nextIds.map(() => ""),
+      grouped: ["dimension"],
+    })
+    chart.updateDimensions()
+
+    expect(chart.getHeatmapSortedIds()).toEqual(["1", "2", "3", "5", "10", "+Inf"])
+    expect(chart.getHeatmapYIndex("3")).toBe(2)
+    expect(chart.getHeatmapYIndex("+Inf")).toBe(5)
+  })
+
+  it("sorts prefixed compatibility bucket ids", () => {
+    const chart = makeHeatmapChart(["bucket_+Inf", "bucket_1024", "bucket_2048"])
+
+    expect(chart.getHeatmapSortedIds()).toEqual(["bucket_1024", "bucket_2048", "bucket_+Inf"])
+    expect(chart.getHeatmapScale()).toBe("binary")
+    expect(chart.getHeatmapYIndex("bucket_1024")).toBe(0)
+    expect(chart.getDimensionIndex("bucket_1024")).toBe(1)
+  })
+
+  it("falls back to payload order for non-numeric heatmaps", () => {
+    const chart = makeHeatmapChart(["low", "high", "+Inf"])
+
+    expect(chart.getHeatmapSortedIds()).toBe(null)
+    expect(chart.getHeatmapScale()).toBe(null)
+    expect(chart.getHeatmapYIndex("high")).toBe(1)
+  })
+
+  it("uses sorted visible heatmap ids for y positions", () => {
+    const chart = makeHeatmapChart(["+Inf", "1", "5", "2"], {
+      selectedLegendDimensions: ["2", "+Inf"],
+    })
+
+    expect(chart.getVisibleHeatmapIds()).toEqual(["2", "+Inf"])
+    expect(chart.getHeatmapYIndex("2")).toBe(0)
+    expect(chart.getHeatmapYIndex("+Inf")).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary

- Sort heatmap buckets numerically, including prefixed Prometheus-style bucket labels and `+Inf`.
- Keep heatmap rendering, y-axis labels, hover bucket selection, and popover rows aligned to the same visible bucket order.
- Remove the API `nonzero` option for heatmaps so bucket scales are not collapsed by all-zero dimensions.
- Crop only zero-only heatmap bucket edges while keeping scale context and all-zero scales intact.
- Keep heatmap popovers in bucket order, with scaled bucket labels, cropped heatmap bucket lists, and no secondary `+N more values` windowing.

## Root Cause

- Heatmap buckets arrived as dimension labels and were treated like generic dimensions in several paths, which caused lexicographic ordering, generic value sorting, generic popover windowing, and API-side nonzero filtering to conflict with heatmap scale semantics.
- The heatmap plotter read values by Dygraph point-array position instead of the original payload row index when visible points were clipped, which could make hover and rendered cells disagree.

## Validation

- `yarn test src/components/line/popover/dimensions.test.js --coverage=false --runInBand`
- `yarn test src/components/line/popover/dimensions.test.js src/sdk/makeChart/makeDimensions.test.js src/helpers/heatmap.test.js src/helpers/heatmapScale.test.js src/chartLibraries/dygraph/hoverX.test.js src/chartLibraries/dygraph/plotters/heatmap.test.js src/chartLibraries/dygraph/tickers/heatmap.test.js src/chartLibraries/dygraph/index.test.js --coverage=false --runInBand`
- `yarn test --coverage=false --runInBand`
- `yarn build`
- Scoped ESLint on changed source/test files
- `yarn to-cloud`
- `sudo ./agent.sh` in `../cloud-frontend`
- `sudo ./agent.sh install` in `../cloud-frontend`

Note: repo-wide `yarn lint` still fails on existing unrelated errors outside this change.
