### PR TITLE
Add percentage aggregation option

### DIFF
--- a/src/components/filterToolbox/aggregate.js
+++ b/src/components/filterToolbox/aggregate.js
@@ -30,6 +30,15 @@ const useItems = chart =>
         "data-track": chart.track("sum"),
       },
       {
+        value: "percentage",
+        label: "Percentage",
+        description:
+          "For each point presented, express the metrics contributing to it as a percentage of their group total.",
+        short: "PCT()",
+        icon: <TextMicro color="textLite">%</TextMicro>,
+        "data-track": chart.track("percentage"),
+      },
+      {
         value: "min",
         label: "Minimum",
         description:

--- a/src/components/filterToolbox/aggregate.test.js
+++ b/src/components/filterToolbox/aggregate.test.js
@@ -1,0 +1,45 @@
+import React from "react"
+import { fireEvent, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { renderWithChart, makeTestChart } from "@jest/testUtilities"
+import Aggregate from "./aggregate"
+
+describe("Aggregate", () => {
+  it("offers percentage aggregation", () => {
+    renderWithChart(<Aggregate />, {
+      attributes: {
+        aggregationMethod: "avg",
+      },
+    })
+
+    fireEvent.click(screen.getByRole("button"))
+
+    expect(screen.getByText("Average")).toBeInTheDocument()
+    expect(screen.getByText("Sum")).toBeInTheDocument()
+    expect(screen.getByText("Percentage")).toBeInTheDocument()
+    expect(screen.getByText("Minimum")).toBeInTheDocument()
+  })
+
+  it("selects percentage aggregation", () => {
+    const { chart } = renderWithChart(<Aggregate />, {
+      attributes: {
+        aggregationMethod: "avg",
+      },
+    })
+
+    fireEvent.click(screen.getByRole("button"))
+    fireEvent.click(screen.getByText("Percentage"))
+
+    expect(chart.getAttribute("aggregationMethod")).toBe("percentage")
+  })
+
+  it("shows percentage as selected", () => {
+    const { chart } = makeTestChart()
+    chart.updateAttribute("aggregationMethod", "percentage")
+
+    renderWithChart(<Aggregate />, { chart })
+
+    expect(screen.getByRole("button")).toHaveAttribute("data-value", "percentage")
+    expect(screen.getByText("PCT()")).toBeInTheDocument()
+  })
+})

--- a/src/components/filterToolbox/postAggregate.js
+++ b/src/components/filterToolbox/postAggregate.js
@@ -1,4 +1,5 @@
 import React, { memo, useMemo } from "react"
+import { TextMicro } from "@netdata/netdata-ui"
 import { useAttributeValue, useChart, useIsMinimal } from "@/components/provider"
 import AggrAvg from "@netdata/netdata-ui/dist/components/icon/assets/aggregation_avg.svg"
 import AggrSum from "@netdata/netdata-ui/dist/components/icon/assets/aggregation_sum.svg"
@@ -25,6 +26,14 @@ const useItems = chart =>
         short: "SUM()",
         icon: <Icon svg={AggrSum} color="textLite" size="10px" />,
         "data-track": chart.track("sum"),
+      },
+      {
+        value: "percentage",
+        label: "Percentage",
+        description: "For each aggregated point, express the metrics as a percentage of their group total.",
+        short: "PCT()",
+        icon: <TextMicro color="textLite">%</TextMicro>,
+        "data-track": chart.track("percentage"),
       },
       {
         value: "min",

--- a/src/components/filterToolbox/postAggregate.test.js
+++ b/src/components/filterToolbox/postAggregate.test.js
@@ -1,0 +1,45 @@
+import React from "react"
+import { fireEvent, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { renderWithChart, makeTestChart } from "@jest/testUtilities"
+import PostAggregate from "./postAggregate"
+
+describe("PostAggregate", () => {
+  it("offers percentage post aggregation", () => {
+    renderWithChart(<PostAggregate />, {
+      attributes: {
+        postAggregationMethod: "avg",
+      },
+    })
+
+    fireEvent.click(screen.getByRole("button"))
+
+    expect(screen.getByText("Average")).toBeInTheDocument()
+    expect(screen.getByText("Sum")).toBeInTheDocument()
+    expect(screen.getByText("Percentage")).toBeInTheDocument()
+    expect(screen.getByText("Minimum")).toBeInTheDocument()
+  })
+
+  it("selects percentage post aggregation", () => {
+    const { chart } = renderWithChart(<PostAggregate />, {
+      attributes: {
+        postAggregationMethod: "avg",
+      },
+    })
+
+    fireEvent.click(screen.getByRole("button"))
+    fireEvent.click(screen.getByText("Percentage"))
+
+    expect(chart.getAttribute("postAggregationMethod")).toBe("percentage")
+  })
+
+  it("shows percentage as selected", () => {
+    const { chart } = makeTestChart()
+    chart.updateAttribute("postAggregationMethod", "percentage")
+
+    renderWithChart(<PostAggregate />, { chart })
+
+    expect(screen.getByRole("button")).toHaveAttribute("data-value", "percentage")
+    expect(screen.getByText("PCT()")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Add Percentage to the metric aggregation and post-aggregation dropdowns.
- Keep request transport unchanged; existing fetch code already forwards the selected aggregation value.
- Add component coverage for visibility, selection, and selected-state rendering.

## Testing
- yarn test --runInBand
- yarn build
- ./node_modules/.bin/eslint src/components/filterToolbox/aggregate.js src/components/filterToolbox/postAggregate.js src/components/filterToolbox/aggregate.test.js src/components/filterToolbox/postAggregate.test.js