### PR TITLE
Improve expanded chart values performance

### DIFF
--- a/src/components/drawer/dimensions/columns.js
+++ b/src/components/drawer/dimensions/columns.js
@@ -4,39 +4,42 @@ import styled from "styled-components"
 import Color, { ColorBar } from "@/components/line/dimensions/color"
 import Name from "@/components/line/dimensions/name"
 import Units, { Value as UnitsText } from "@/components/line/dimensions/units"
-import Value, { Value as ValuePart } from "@/components/line/dimensions/value"
+import { Value as ValuePart } from "@/components/line/dimensions/value"
 import {
   useChart,
   useAttributeValue,
   useVisibleDimensionId,
   getValueByPeriod,
   convert,
+  useConverted,
 } from "@/components/provider"
 import Label from "@/components/filterToolbox/label"
 import { rowFlavours } from "@/components/line/popover/dimensions"
 
-const makeNumberSortingFn =
-  (chart, { key, period, objKey }) =>
+const getCachedValue = (chart, valueCache, id, { key, period, objKey, allowNull = true }) => {
+  if (!objKey && valueCache) return valueCache.get(id, key, { period })
+
+  return (getValueByPeriod[period] || getValueByPeriod.latest)({
+    chart,
+    id,
+    valueKey: key,
+    objKey,
+    allowNull,
+  })
+}
+
+export const makeNumberSortingFn =
+  (chart, { key, period, objKey, valueCache }) =>
   (rowA, rowB) => {
     const aId = rowA.original
     const bId = rowB.original
 
-    const aValue = getValueByPeriod[period]({
-      chart,
-      id: aId,
-      valueKey: key,
-      objKey,
-    })
-    const bValue = getValueByPeriod[period]({
-      chart,
-      id: bId,
-      valueKey: key,
-      objKey,
-    })
+    const aValue = getCachedValue(chart, valueCache, aId, { key, period, objKey })
+    const bValue = getCachedValue(chart, valueCache, bId, { key, period, objKey })
 
     const result = aValue - bValue
 
-    if (!result)
+    if (!result || isNaN(result))
       return aId.localeCompare(bId, undefined, {
         sensitivity: "accent",
         ignorePunctuation: true,
@@ -148,7 +151,48 @@ const ValueOnDot = ({ children, fractionDigits = 0, ...rest }) => {
   )
 }
 
-export const valueColumn = chart => ({
+const CachedValue = ({
+  id,
+  visible,
+  valueKey = "value",
+  period = "latest",
+  objKey,
+  unitsKey,
+  valueCache,
+  Component = ValuePart,
+  fractionDigits,
+  ...rest
+}) => {
+  const chart = useChart()
+  const value = getCachedValue(chart, valueCache, id, {
+    key: valueKey,
+    period,
+    objKey,
+  })
+  const convertedValue = useConverted(value, { valueKey, fractionDigits, dimensionId: id, unitsKey })
+
+  if (!visible) return null
+
+  return <Component {...rest}>{convertedValue}</Component>
+}
+
+const renderValueString = (
+  chart,
+  row,
+  { key = "value", period = "latest", objKey, unitsKey, valueCache, fractionDigits }
+) =>
+  convert(
+    chart,
+    getCachedValue(chart, valueCache, row.original, { key, period, objKey }),
+    {
+      valueKey: key,
+      fractionDigits,
+      dimensionId: row.original,
+      unitsKey,
+    }
+  )
+
+export const valueColumn = (chart, { valueCache } = {}) => ({
   id: "value",
   header: (
     <Flex column>
@@ -160,9 +204,9 @@ export const valueColumn = chart => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(chart, getValueByPeriod.latest({ chart, id: row.original }), {
+    renderValueString(chart, row, {
+      valueCache,
       fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-      dimensionId: row.original,
     }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
@@ -170,19 +214,20 @@ export const valueColumn = chart => ({
     const chart = useChart()
 
     return (
-      <Value
+      <CachedValue
         period="latest"
         id={id}
         visible={visible}
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: "basic",
+  sortingFn: makeNumberSortingFn(chart, { key: "value", period: "latest", valueCache }),
 })
 
-export const anomalyColumn = (chart, { period, objKey }) => ({
+export const anomalyColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-arp` : "arp",
   header: (
     <Flex column>
@@ -194,42 +239,35 @@ export const anomalyColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "arp",
-
-        objKey,
-      }),
-      {
-        valueKey: "arp",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "arp",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="arp"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
         color="anomalyTextFocus"
       />
     )
   },
-  sortingFn: "basic",
+  sortingFn: makeNumberSortingFn(chart, { key: "arp", period, objKey, valueCache }),
 })
 
-export const minColumn = (chart, { period, objKey }) => ({
+export const minColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-min` : "min",
   header: (
     <Flex column>
@@ -241,40 +279,34 @@ export const minColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "min",
-        objKey,
-      }),
-      {
-        valueKey: "min",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "min",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="min"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "min", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "min", period, objKey, valueCache }),
 })
 
-export const avgColumn = (chart, { period, objKey }) => ({
+export const avgColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-avg` : "avg",
   header: (
     <Flex column>
@@ -286,41 +318,34 @@ export const avgColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "avg",
-
-        objKey,
-      }),
-      {
-        valueKey: "avg",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "avg",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="avg"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "avg", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "avg", period, objKey, valueCache }),
 })
 
-export const maxColumn = (chart, { period, objKey }) => ({
+export const maxColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-max` : "max",
   header: (
     <Flex column>
@@ -332,41 +357,34 @@ export const maxColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "max",
-
-        objKey,
-      }),
-      {
-        valueKey: "max",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "max",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="max"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "max", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "max", period, objKey, valueCache }),
 })
 
-export const medianColumn = (chart, { period, objKey }) => ({
+export const medianColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-median` : "median",
   header: (
     <Flex column>
@@ -378,40 +396,34 @@ export const medianColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "median",
-        objKey,
-      }),
-      {
-        valueKey: "median",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "median",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="median"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "median", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "median", period, objKey, valueCache }),
 })
 
-export const stdDevColumn = (chart, { period, objKey }) => ({
+export const stdDevColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-stddev` : "stddev",
   header: (
     <Flex column>
@@ -423,40 +435,34 @@ export const stdDevColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "stddev",
-        objKey,
-      }),
-      {
-        valueKey: "stddev",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "stddev",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="stddev"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "stddev", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "stddev", period, objKey, valueCache }),
 })
 
-export const p95Column = (chart, { period, objKey }) => ({
+export const p95Column = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-p95` : "p95",
   header: (
     <Flex column>
@@ -468,40 +474,34 @@ export const p95Column = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "p95",
-        objKey,
-      }),
-      {
-        valueKey: "p95",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "p95",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="p95"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "p95", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "p95", period, objKey, valueCache }),
 })
 
-export const rangeColumn = (chart, { period, objKey }) => ({
+export const rangeColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-range` : "range",
   header: (
     <Flex column>
@@ -513,40 +513,34 @@ export const rangeColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "range",
-        objKey,
-      }),
-      {
-        valueKey: "range",
-        fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
-        dimensionId: row.original,
-      }
-    ),
+    renderValueString(chart, row, {
+      key: "range",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: chart.getAttribute("unitsConversionFractionDigits"),
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="range"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={chart.getAttribute("unitsConversionFractionDigits")}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "range", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "range", period, objKey, valueCache }),
 })
 
-export const volumeColumn = (chart, { period, objKey }) => ({
+export const volumeColumn = (chart, { period, objKey, valueCache }) => ({
   id: objKey ? `${objKey}-volume` : "volume",
   header: (
     <Flex column>
@@ -558,31 +552,29 @@ export const volumeColumn = (chart, { period, objKey }) => ({
   size: 60,
   minSize: 60,
   renderString: row =>
-    convert(
-      chart,
-      getValueByPeriod[period]({
-        chart,
-        id: row.original,
-        valueKey: "volume",
-        objKey,
-      }),
-      { valueKey: "volume", fractionDigits: 1, dimensionId: row.original }
-    ),
+    renderValueString(chart, row, {
+      key: "volume",
+      period,
+      objKey,
+      valueCache,
+      fractionDigits: 1,
+    }),
   cell: ({ row: { original: id } }) => {
     const visible = useVisibleDimensionId(id)
 
     return (
-      <Value
+      <CachedValue
         period={period}
         objKey={objKey}
         textAlign="right"
         id={id}
         visible={visible}
         valueKey="volume"
+        valueCache={valueCache}
         Component={ValueOnDot}
         fractionDigits={1}
       />
     )
   },
-  sortingFn: makeNumberSortingFn(chart, { key: "volume", period, objKey }),
+  sortingFn: makeNumberSortingFn(chart, { key: "volume", period, objKey, valueCache }),
 })

--- a/src/components/drawer/dimensions/index.js
+++ b/src/components/drawer/dimensions/index.js
@@ -16,6 +16,7 @@ import {
   rangeColumn,
   volumeColumn,
 } from "./columns"
+import useDimensionValueCache from "./useDimensionValueCache"
 
 const noop = () => {}
 
@@ -25,7 +26,6 @@ const useColumns = (period, options = {}) => {
 
   return useMemo(() => {
     const columnOptions = { period, ...options }
-    const dbOptions = { ...columnOptions, objKey: "dbDimensions", unitsKey: "dbUnits" }
 
     return [
       {
@@ -33,7 +33,7 @@ const useColumns = (period, options = {}) => {
         header: () => <TextSmall>Dimension ({hover ? "hovering" : "latest"} value)</TextSmall>,
         headerString: () => "",
         fullWidth: true,
-        columns: [labelColumn(chart), valueColumn(chart)],
+        columns: [labelColumn(chart), valueColumn(chart, columnOptions)],
       },
       {
         id: "visible",
@@ -68,7 +68,7 @@ const useColumns = (period, options = {}) => {
       //   ],
       // },
     ]
-  }, [period, !!hover])
+  }, [period, !!hover, options.valueCache])
 }
 
 const meta = (row, cell, index) => ({
@@ -87,9 +87,10 @@ const Dimensions = () => {
 
   const tab = useAttributeValue("drawer.tab")
   const period = tab === "selectedArea" ? "highlight" : "window"
-  const columns = useColumns(period)
 
   const showAdvancedStats = useAttributeValue("drawer.showAdvancedStats", false)
+  const valueCache = useDimensionValueCache(period, { includeAdvancedStats: showAdvancedStats })
+  const columns = useColumns(period, { valueCache })
 
   const chart = useChart()
   useMemo(() => chart.makeChartUI("custom", "bars"), [])
@@ -118,7 +119,15 @@ const Dimensions = () => {
   }, [chart])
 
   return (
-    <Flex gap={2}>
+    <Flex
+      flex
+      column
+      gap={2}
+      height="100%"
+      overflow="hidden"
+      style={{ minHeight: 0 }}
+      data-testid="chart-values-table-container"
+    >
       <Table
         key={period}
         enableSorting

--- a/src/components/drawer/dimensions/index.test.js
+++ b/src/components/drawer/dimensions/index.test.js
@@ -48,4 +48,17 @@ describe("Dimensions", () => {
     expect(screen.getByText("Avg")).toBeInTheDocument()
     expect(screen.getByText("Max")).toBeInTheDocument()
   })
+
+  it("constrains the table viewport for virtualization", () => {
+    renderWithChart(<Dimensions />)
+
+    const container = screen.getByTestId("chart-values-table-container")
+
+    expect(container).toHaveAttribute("height", "100%")
+    expect(container).toHaveStyle({
+      flexDirection: "column",
+      minHeight: "0",
+      overflow: "hidden",
+    })
+  })
 })

--- a/src/components/drawer/dimensions/useDimensionValueCache.js
+++ b/src/components/drawer/dimensions/useDimensionValueCache.js
@@ -1,0 +1,260 @@
+import { useMemo, useReducer } from "react"
+import { calculateMedian, calculatePercentile, calculateStdDev } from "@/helpers/statistics"
+import { isIncremental } from "@/helpers/heatmap"
+import { useAttributeValue, useChart, useImmediateListener, usePayload } from "@/components/provider"
+
+const nextVersion = version => version + 1
+
+const advancedStatKeys = new Set(["median", "stddev", "p95", "range", "volume"])
+const responseStatKeys = new Set(["min", "avg", "max", "arp"])
+
+const isValidNumber = value => value !== null && !isNaN(value) && isFinite(value)
+
+const getVisibleDimensionId = (chart, id) =>
+  chart.isDimensionVisible(id) ? id : chart.getVisibleDimensionIds()[0]
+
+const getViewStatValue = (chart, id, key, { abs, period }) => {
+  if (period !== "window" || isIncremental(chart)) return undefined
+
+  const visibleId = getVisibleDimensionId(chart, id)
+  if (!visibleId) return undefined
+
+  const dimensionIndex = chart.getDimensionIndex(visibleId)
+  if (typeof dimensionIndex !== "number") return undefined
+
+  const stats = chart.getAttribute("viewDimensions")?.sts
+  if (!stats) return undefined
+
+  if (key === "range") {
+    const min = stats.min?.[dimensionIndex]
+    const max = stats.max?.[dimensionIndex]
+
+    if (!isValidNumber(min) || !isValidNumber(max)) return undefined
+    if (abs && (min < 0 || max < 0)) return undefined
+
+    return max - min
+  }
+
+  if (!responseStatKeys.has(key)) return undefined
+
+  const value = stats[key]?.[dimensionIndex]
+  if (!isValidNumber(value)) return undefined
+
+  if (key !== "arp" && abs) {
+    const min = stats.min?.[dimensionIndex]
+    const max = stats.max?.[dimensionIndex]
+
+    if ((isValidNumber(min) && min < 0) || (isValidNumber(max) && max < 0)) return undefined
+  }
+
+  return value
+}
+
+const getDirectRowDimensionValue = (
+  chart,
+  id,
+  row,
+  { dimensionIndex, valueKey = "value", abs = true, allowNull = false }
+) => {
+  if (dimensionIndex === undefined || isIncremental(chart)) {
+    return chart.getRowDimensionValue(id, row, { valueKey, abs, allowNull })
+  }
+
+  let value = row?.[dimensionIndex + 1]
+  if (typeof value === "undefined") return null
+
+  value = value !== null && typeof value === "object" ? value[valueKey] : value
+  value = allowNull && value === null ? value : abs ? Math.abs(value) : value
+
+  return value
+}
+
+const getPeriodRows = (chart, payload, period) => {
+  const data = payload?.data || []
+  if (!data.length) return null
+
+  if (period !== "highlight") return data
+
+  const { highlight } = chart.getAttribute("overlays")
+  if (!highlight?.range) return null
+
+  const [start, end] = highlight.range
+
+  return data.filter(row => {
+    const timestamp = row[0] / 1000
+    return timestamp >= start && timestamp <= end
+  })
+}
+
+const calculateDimensionStats = (
+  chart,
+  id,
+  rows,
+  { abs, includeAdvancedStats, requestedKey }
+) => {
+  if (!rows?.length) return null
+
+  id = getVisibleDimensionId(chart, id)
+  if (!id) return null
+
+  const dimensionIndex = chart.getDimensionIndex(id)
+  const includeAdvanced = includeAdvancedStats || advancedStatKeys.has(requestedKey)
+  const values = includeAdvanced ? [] : null
+  let count = 0
+  let sum = 0
+  let min = Infinity
+  let max = -Infinity
+  let volume = 0
+
+  for (let i = 0; i < rows.length; i++) {
+    const value = getDirectRowDimensionValue(chart, id, rows[i], {
+      dimensionIndex,
+      abs,
+      allowNull: true,
+    })
+
+    if (!isValidNumber(value)) continue
+
+    count++
+    sum += value
+    volume += Math.abs(value)
+    if (value < min) min = value
+    if (value > max) max = value
+    if (values) values.push(value)
+  }
+
+  if (!count) return null
+
+  const avg = sum / count
+  const stats = {
+    min,
+    avg,
+    max,
+    arp: 0,
+  }
+
+  if (!includeAdvanced) return stats
+
+  return {
+    ...stats,
+    median: calculateMedian(values),
+    stddev: calculateStdDev(values, avg),
+    p95: calculatePercentile(values, 95),
+    range: max - min,
+    volume,
+  }
+}
+
+const getLatestIndex = (chart, payload) => {
+  const all = payload?.all || []
+  if (!all.length) return -1
+
+  const hover = chart.getAttribute("hoverX")
+  const index = hover ? chart.getClosestRow(hover[0]) : -1
+
+  return index === -1 ? all.length - 1 : index
+}
+
+export const createDimensionValueCache = (
+  chart,
+  { payload = chart.getPayload(), period = "window", includeAdvancedStats = false } = {}
+) => {
+  const latestValues = new Map()
+  const statsById = new Map()
+  const rows = getPeriodRows(chart, payload, period)
+  const abs = chart.getAttribute("abs")
+  const latestIndex = getLatestIndex(chart, payload)
+
+  const getLatestValue = (id, valueKey) => {
+    const key = `${id}\u0000${valueKey}`
+    if (latestValues.has(key)) return latestValues.get(key)
+
+    const visibleId = getVisibleDimensionId(chart, id)
+    const dimensionIndex = visibleId ? chart.getDimensionIndex(visibleId) : undefined
+    const value =
+      latestIndex === -1 || !visibleId
+        ? null
+        : getDirectRowDimensionValue(chart, visibleId, payload?.all?.[latestIndex], {
+            dimensionIndex,
+            valueKey,
+            abs,
+            allowNull: true,
+          })
+
+    latestValues.set(key, value)
+
+    return value
+  }
+
+  const getStats = (id, requestedKey) => {
+    const cached = statsById.get(id)
+    const needsAdvanced = includeAdvancedStats || advancedStatKeys.has(requestedKey)
+
+    if (cached?.stats && Object.prototype.hasOwnProperty.call(cached.stats, requestedKey)) {
+      return cached.stats
+    }
+
+    const responseStat = getViewStatValue(chart, id, requestedKey, { abs, period })
+
+    if (typeof responseStat !== "undefined") {
+      const stats = {
+        ...(cached?.stats || {}),
+        [requestedKey]: responseStat,
+      }
+
+      statsById.set(id, {
+        includeAdvanced: cached?.includeAdvanced || false,
+        stats,
+      })
+
+      return stats
+    }
+
+    if (cached && (!needsAdvanced || cached.includeAdvanced)) return cached.stats
+
+    const stats = calculateDimensionStats(chart, id, rows, {
+      abs,
+      includeAdvancedStats,
+      requestedKey,
+    })
+
+    statsById.set(id, {
+      includeAdvanced: needsAdvanced,
+      stats,
+    })
+
+    return stats
+  }
+
+  return {
+    get: (id, valueKey = "value", { period: valuePeriod = period } = {}) => {
+      if (valuePeriod === "latest") return getLatestValue(id, valueKey)
+
+      return getStats(id, valueKey)?.[valueKey] ?? null
+    },
+  }
+}
+
+const useVisibleDimensionsVersion = chart => {
+  const [version, bumpVersion] = useReducer(nextVersion, 0)
+
+  useImmediateListener(() => chart.on("visibleDimensionsChanged", bumpVersion), [chart])
+
+  return version
+}
+
+const useDimensionValueCache = (period, { includeAdvancedStats = false } = {}) => {
+  const chart = useChart()
+  const payload = usePayload()
+  const hover = useAttributeValue("hoverX")
+  const overlays = useAttributeValue("overlays")
+  const abs = useAttributeValue("abs")
+  const visibleDimensionsVersion = useVisibleDimensionsVersion(chart)
+
+  return useMemo(
+    () => createDimensionValueCache(chart, { payload, period, includeAdvancedStats }),
+    [chart, payload, period, includeAdvancedStats, hover, overlays, abs, visibleDimensionsVersion]
+  )
+}
+
+export default useDimensionValueCache

--- a/src/components/drawer/dimensions/useDimensionValueCache.test.js
+++ b/src/components/drawer/dimensions/useDimensionValueCache.test.js
@@ -1,0 +1,208 @@
+import { makeTestChart } from "@jest/testUtilities"
+import { makeNumberSortingFn } from "./columns"
+import { createDimensionValueCache } from "./useDimensionValueCache"
+
+const getCellValue = cell => (cell !== null && typeof cell === "object" ? cell[0] : cell)
+
+const makeStats = (ids, rows) =>
+  ids.reduce(
+    (stats, id, index) => {
+      const values = rows.map(row => getCellValue(row[index + 1]))
+
+      stats.min.push(Math.min(...values))
+      stats.avg.push(values.reduce((sum, value) => sum + value, 0) / values.length)
+      stats.max.push(Math.max(...values))
+      stats.arp.push(0)
+
+      return stats
+    },
+    { min: [], avg: [], max: [], arp: [] }
+  )
+
+const makePayload = (ids, rows, { stats = makeStats(ids, rows) } = {}) => ({
+  summary: {
+    contexts: [{ id: "test.context", sts: { min: 0, max: 100 } }],
+  },
+  db: {
+    update_every: 1,
+    dimensions: {
+      ids,
+      names: ids,
+      units: ids.map(() => "requests"),
+    },
+    units: "requests",
+  },
+  view: {
+    title: "Test chart",
+    units: "requests",
+    chart_type: "line",
+    dimensions: {
+      ids,
+      names: ids,
+      units: ids.map(() => "requests"),
+      sts: stats,
+    },
+  },
+  result: {
+    labels: ["time", ...ids],
+    point: { value: 0, arp: 1, pa: 2 },
+    data: rows,
+  },
+})
+
+const value = number => [number, 0, 0]
+
+const loadChart = async payload => {
+  const { chart } = makeTestChart({ mockData: payload })
+  const loaded = new Promise(resolve => chart.on("successFetch", resolve))
+
+  chart.doneFetch(payload)
+  await loaded
+
+  return chart
+}
+
+describe("dimension value cache", () => {
+  it("calculates latest values and window stats from the chart payload", async () => {
+    const chart = await loadChart(
+      makePayload(["low", "mid", "high"], [
+        [1000, value(1), value(2), value(10)],
+        [2000, value(1), value(4), value(20)],
+        [3000, value(1), value(6), value(30)],
+      ])
+    )
+
+    const cache = createDimensionValueCache(chart, { period: "window", includeAdvancedStats: true })
+
+    expect(cache.get("mid", "value", { period: "latest" })).toBe(6)
+    expect(cache.get("mid", "min", { period: "window" })).toBe(2)
+    expect(cache.get("mid", "avg", { period: "window" })).toBe(4)
+    expect(cache.get("mid", "max", { period: "window" })).toBe(6)
+    expect(cache.get("mid", "median", { period: "window" })).toBe(4)
+    expect(cache.get("mid", "range", { period: "window" })).toBe(4)
+    expect(cache.get("mid", "volume", { period: "window" })).toBe(12)
+  })
+
+  it("sorts by cached stat values without rescanning dimensions on every comparison", async () => {
+    const ids = ["a", "b", "c", "d", "e", "f"]
+    const rows = [
+      [1000, value(5), value(1), value(3), value(4), value(2), value(6)],
+      [2000, value(5), value(1), value(3), value(4), value(2), value(6)],
+      [3000, value(5), value(1), value(3), value(4), value(2), value(6)],
+    ]
+    const chart = await loadChart(makePayload(ids, rows))
+    const valueCache = createDimensionValueCache(chart, { period: "window" })
+    const originalGetRowDimensionValue = chart.getRowDimensionValue
+    let getRowDimensionValueCalls = 0
+
+    chart.getRowDimensionValue = (...args) => {
+      getRowDimensionValueCalls++
+      return originalGetRowDimensionValue(...args)
+    }
+
+    try {
+      const sortingFn = makeNumberSortingFn(chart, {
+        key: "avg",
+        period: "window",
+        valueCache,
+      })
+      const tableRows = chart.getDimensionIds().map(id => ({ original: id }))
+
+      tableRows.sort(sortingFn)
+
+      const callsAfterFirstSort = getRowDimensionValueCalls
+
+      expect(tableRows.map(row => row.original)).toEqual(["b", "e", "c", "d", "a", "f"])
+      expect(callsAfterFirstSort).toBe(0)
+
+      tableRows.reverse().sort(sortingFn)
+
+      expect(getRowDimensionValueCalls).toBe(callsAfterFirstSort)
+    } finally {
+      chart.getRowDimensionValue = originalGetRowDimensionValue
+    }
+  })
+
+  it("uses response window stats instead of recalculating row values", async () => {
+    const chart = await loadChart(
+      makePayload(
+        ["a", "b"],
+        [
+          [1000, value(100), value(1)],
+          [2000, value(100), value(1)],
+        ],
+        {
+          stats: {
+            min: [10, 20],
+            avg: [30, 40],
+            max: [50, 60],
+            arp: [1, 2],
+          },
+        }
+      )
+    )
+    const originalGetRowDimensionValue = chart.getRowDimensionValue
+    let getRowDimensionValueCalls = 0
+
+    chart.getRowDimensionValue = (...args) => {
+      getRowDimensionValueCalls++
+      return originalGetRowDimensionValue(...args)
+    }
+
+    try {
+      const cache = createDimensionValueCache(chart, { period: "window" })
+
+      expect(cache.get("a", "min", { period: "window" })).toBe(10)
+      expect(cache.get("a", "avg", { period: "window" })).toBe(30)
+      expect(cache.get("a", "max", { period: "window" })).toBe(50)
+      expect(cache.get("a", "arp", { period: "window" })).toBe(1)
+      expect(cache.get("a", "range", { period: "window" })).toBe(40)
+      expect(getRowDimensionValueCalls).toBe(0)
+    } finally {
+      chart.getRowDimensionValue = originalGetRowDimensionValue
+    }
+  })
+
+  it("keeps selected-area stats scoped to highlighted rows", async () => {
+    const chart = await loadChart(
+      makePayload(
+        ["a"],
+        [[1000, value(1)], [2000, value(3)], [3000, value(100)]],
+        {
+          stats: {
+            min: [1000],
+            avg: [1000],
+            max: [1000],
+            arp: [0],
+          },
+        }
+      )
+    )
+
+    chart.setAttribute("overlays", { highlight: { range: [1, 2] } })
+
+    const cache = createDimensionValueCache(chart, { period: "highlight" })
+
+    expect(cache.get("a", "min", { period: "highlight" })).toBe(1)
+    expect(cache.get("a", "avg", { period: "highlight" })).toBe(2)
+    expect(cache.get("a", "max", { period: "highlight" })).toBe(3)
+  })
+
+  it("keeps incremental heatmap bucket delta semantics", async () => {
+    const chart = await loadChart(
+      makePayload(["bucket_0", "bucket_1", "bucket_2"], [
+        [1000, value(10), value(15), value(25)],
+        [2000, value(20), value(30), value(45)],
+      ])
+    )
+
+    chart.setAttribute("chartType", "heatmap")
+    chart.setAttribute("heatmapType", "incremental")
+
+    const cache = createDimensionValueCache(chart, { period: "window" })
+
+    expect(cache.get("bucket_1", "avg", { period: "window" })).toBe(7.5)
+    expect(cache.get("bucket_2", "avg", { period: "window" })).toBe(12.5)
+    expect(cache.get("bucket_1", "value", { period: "latest" })).toBe(10)
+  })
+})

--- a/src/components/drawer/index.js
+++ b/src/components/drawer/index.js
@@ -18,6 +18,7 @@ const componentsByAction = {
 const Drawer = () => {
   const expandedHeight = useAttributeValue("expandedHeight")
   const action = useAttributeValue("drawer.action")
+  const isValuesAction = action === actions.values
 
   const Component = useMemo(() => {
     return componentsByAction[action] || componentsByAction.compare
@@ -32,7 +33,15 @@ const Drawer = () => {
       background="mainChartBg"
     >
       <Header padding={[0, 2, 2, 2]} />
-      <Flex flex column padding={[0, 2, 3, 2]} overflow={{ vertical: "scroll" }} height="100%">
+      <Flex
+        flex
+        column
+        padding={[0, 2, 3, 2]}
+        overflow={{ vertical: isValuesAction ? "hidden" : "scroll" }}
+        height="100%"
+        style={{ minHeight: 0 }}
+        data-testid="drawer-content"
+      >
         <Component />
       </Flex>
     </Flex>

--- a/src/components/drawer/index.test.js
+++ b/src/components/drawer/index.test.js
@@ -1,0 +1,30 @@
+import React from "react"
+import { screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { renderWithChart } from "@jest/testUtilities"
+import Drawer from "./index"
+import { actions } from "./constants"
+
+describe("Drawer", () => {
+  it("lets the values table own vertical scrolling", () => {
+    renderWithChart(<Drawer />, {
+      attributes: { drawer: { action: actions.values } },
+    })
+
+    expect(screen.getByTestId("drawer-content")).toHaveStyle({
+      minHeight: "0",
+      overflowY: "hidden",
+    })
+  })
+
+  it("keeps drawer scrolling for non-table actions", () => {
+    renderWithChart(<Drawer />, {
+      attributes: { drawer: { action: actions.compare } },
+    })
+
+    expect(screen.getByTestId("drawer-content")).toHaveStyle({
+      minHeight: "0",
+      overflowY: "scroll",
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Cache expanded Chart Values lookups per payload so render and sort paths do not rescan every point for every visible dimension.
- Reuse response-provided window stats for min, avg, max, and anomaly rate when safe.
- Bound the Chart Values drawer/table viewport so the table virtualizer renders the visible window instead of thousands of rows.
- Keep the values table as the only vertical scroller for that drawer action, avoiding the double-scrollbar layout.

## Root Cause

Expanded Chart Values became slow with thousands of grouped dimensions because value/stat cells repeatedly recomputed per-dimension stats from row data. The drawer content also gave the table an effectively unbounded height, so virtualization could render all rows instead of only the visible rows.

## Validation

- `yarn test --runInBand --coverage=false --silent`
- `yarn build`
