### PR TITLE
Mute chart info line

### DIFF
--- a/src/chartLibraries/dygraph/plotters/annotations.js
+++ b/src/chartLibraries/dygraph/plotters/annotations.js
@@ -1,5 +1,7 @@
 import { enums, parts, check, colors, priorities } from "@/helpers/annotations"
 
+const annotationLineAlpha = 0.45
+
 export default chartUI => plotter => {
   if (!chartUI) return
 
@@ -50,12 +52,17 @@ export default chartUI => plotter => {
       ctx.fillRect(center_x - bar_width / 2, h - 4, bar_width, h)
       ctx.strokeRect(center_x - bar_width / 2, h - 4, bar_width, h)
 
+      const previousAlpha = ctx.globalAlpha ?? 1
+      ctx.globalAlpha = annotationLineAlpha
+
       values.forEach(val => {
         ctx.strokeStyle = ctx.fillStyle = colors[val] || "transparent"
 
         ctx.fillRect(center_x - bar_width / 2, h - 4, bar_width, h)
         ctx.strokeRect(center_x - bar_width / 2, h - 4, bar_width, h)
       })
+
+      ctx.globalAlpha = previousAlpha
     })
   }
 }

--- a/src/chartLibraries/dygraph/plotters/annotations.test.js
+++ b/src/chartLibraries/dygraph/plotters/annotations.test.js
@@ -4,12 +4,15 @@ describe("annotations plotter", () => {
   let mockChartUI
   let mockPlotter
   let mockCtx
+  let fillAlphaValues
 
   beforeEach(() => {
+    fillAlphaValues = []
     mockCtx = {
       strokeStyle: "black",
       fillStyle: "black",
-      fillRect: jest.fn(),
+      globalAlpha: 1,
+      fillRect: jest.fn(() => fillAlphaValues.push(mockCtx.globalAlpha)),
       strokeRect: jest.fn(),
     }
 
@@ -73,6 +76,14 @@ describe("annotations plotter", () => {
 
     expect(mockCtx.fillRect).toHaveBeenCalled()
     expect(mockCtx.strokeRect).toHaveBeenCalled()
+  })
+
+  it("renders the annotation line with reduced intensity", () => {
+    const plotter = annotationsPlotter(mockChartUI)
+    plotter(mockPlotter)
+
+    expect(fillAlphaValues).toContain(0.45)
+    expect(mockCtx.globalAlpha).toBe(1)
   })
 
   it("processes points with selected legend dimensions", () => {


### PR DESCRIPTION
## Summary

- Reduce the visual intensity of the dygraph annotation/info line by drawing annotation segments with lower canvas alpha.
- Restore the previous canvas alpha after annotation drawing so later canvas operations are not affected.
- Add coverage for the muted rendering behavior.

## Impact

This keeps existing annotation semantics, labels, and popover behavior unchanged. The change only makes the bottom info line less visually intense.

## Validation

- `yarn test src/chartLibraries/dygraph/plotters/annotations.test.js --runInBand`
- `./node_modules/.bin/eslint src/chartLibraries/dygraph/plotters/annotations.js src/chartLibraries/dygraph/plotters/annotations.test.js`
- `yarn build`
- `yarn test --runInBand`

Note: full `yarn lint` still reports existing unrelated repository-wide lint issues outside this change.