### PR TITLE
Improve heatmap and chart values rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "6.10.10",
+  "version": "6.11.0",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",

--- a/src/components/line/popover/dimension.js
+++ b/src/components/line/popover/dimension.js
@@ -8,6 +8,7 @@ import { useChart, useVisibleDimensionId } from "@/components/provider"
 import { labels as annotationLabels } from "@/helpers/annotations"
 import { useIsHeatmap } from "@/helpers/heatmap"
 import { rowFlavours } from "./dimensions"
+import { popoverGridColumns } from "./layout"
 
 const GridRow = styled(Flex).attrs({
   position: "relative",
@@ -24,6 +25,31 @@ const ColorBackground = styled(ColorBar).attrs({
   backgroundOpacity: 0.4,
   round: 0.5,
 })``
+
+const getInfoColumnWidth = rowFlavour =>
+  rowFlavour === rowFlavours.ANNOTATIONS
+    ? popoverGridColumns.annotationsInfo
+    : popoverGridColumns.info
+
+const DimensionNameCell = styled.div.attrs({
+  "data-testid": "chartPopover-dimensionNameCell",
+})`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.constants.SIZE_SUB_UNIT}px;
+  position: relative;
+  min-width: 0;
+  max-width: calc(
+    80vw - 32px - ${popoverGridColumns.value} - ${popoverGridColumns.anomaly} -
+      ${({ $rowFlavour }) => getInfoColumnWidth($rowFlavour)}
+  );
+  overflow: hidden;
+
+  [data-testid="chartDimensions-name"] {
+    min-width: 0;
+    max-width: 100%;
+  }
+`
 
 const rowValueKeys = {
   ANOMALY_RATE: "arp",
@@ -73,7 +99,7 @@ const Dimension = ({ id, strong, rowFlavour }) => {
 
   return (
     <GridRow opacity={visible ? null : "weak"}>
-      <Flex alignItems="center" gap={1} position="relative">
+      <DimensionNameCell $rowFlavour={rowFlavour}>
         <ColorBackground
           id={id}
           valueKey={rowValueKeys[rowFlavour] || rowValueKeys.default}
@@ -89,7 +115,7 @@ const Dimension = ({ id, strong, rowFlavour }) => {
           noTooltip
           color={strong ? "textFocus" : "text"}
         />
-      </Flex>
+      </DimensionNameCell>
       <Value
         id={id}
         strong={strong}

--- a/src/components/line/popover/dimension.js
+++ b/src/components/line/popover/dimension.js
@@ -31,19 +31,18 @@ const getInfoColumnWidth = rowFlavour =>
     ? popoverGridColumns.annotationsInfo
     : popoverGridColumns.info
 
-const DimensionNameCell = styled.div.attrs({
+const DimensionNameCell = styled(Flex).attrs({
   "data-testid": "chartPopover-dimensionNameCell",
+  alignItems: "center",
+  gap: 1,
+  position: "relative",
+  overflow: "hidden",
+  width: { min: 0 },
 })`
-  display: flex;
-  align-items: center;
-  gap: ${({ theme }) => theme.constants.SIZE_SUB_UNIT}px;
-  position: relative;
-  min-width: 0;
   max-width: calc(
     80vw - 32px - ${popoverGridColumns.value} - ${popoverGridColumns.anomaly} -
-      ${({ $rowFlavour }) => getInfoColumnWidth($rowFlavour)}
+      ${({ rowFlavour }) => getInfoColumnWidth(rowFlavour)}
   );
-  overflow: hidden;
 
   [data-testid="chartDimensions-name"] {
     min-width: 0;
@@ -99,7 +98,7 @@ const Dimension = ({ id, strong, rowFlavour }) => {
 
   return (
     <GridRow opacity={visible ? null : "weak"}>
-      <DimensionNameCell $rowFlavour={rowFlavour}>
+      <DimensionNameCell rowFlavour={rowFlavour}>
         <ColorBackground
           id={id}
           valueKey={rowValueKeys[rowFlavour] || rowValueKeys.default}

--- a/src/components/line/popover/dimensions.js
+++ b/src/components/line/popover/dimensions.js
@@ -6,15 +6,18 @@ import Units from "@/components/line/dimensions/units"
 import UpdateEvery from "./updateEvery"
 import Timestamp from "./timestamp"
 import Dimension from "./dimension"
+import { popoverGridColumns } from "./layout"
 
 const Container = styled(Flex).attrs({
   round: true,
-  width: { min: "196px", max: "80vw" },
+  width: { min: "300px", max: "80vw" },
   background: "dropdown",
   column: true,
   padding: [4],
   gap: 1,
 })`
+  box-sizing: border-box;
+  width: fit-content;
   box-shadow:
     0px 8px 12px rgba(9, 30, 66, 0.15),
     0px 0px 1px rgba(9, 30, 66, 0.31);
@@ -23,10 +26,12 @@ const Container = styled(Flex).attrs({
 const Grid = styled.div`
   display: grid;
   width: 100%;
-  grid-template-columns: minmax(200px, 2fr) minmax(80px, 1.5fr) minmax(80px, 1fr) minmax(
-      80px,
-      0.5fr
-    );
+  max-width: 100%;
+  grid-template-columns: minmax(0, auto) ${popoverGridColumns.value} ${popoverGridColumns.anomaly}
+    ${({ $rowFlavour }) =>
+      $rowFlavour === rowFlavours.ANNOTATIONS
+        ? popoverGridColumns.annotationsInfo
+        : popoverGridColumns.info};
   align-items: center;
 `
 
@@ -112,7 +117,7 @@ const Dimensions = () => {
       <Flex flex={false} height={3}>
         {from > 0 && <TextNano color="textLite">↑{from} more values</TextNano>}
       </Flex>
-      <Grid gap={1} column>
+      <Grid data-testid="chartPopover-grid" $rowFlavour={rowFlavour}>
         <GridHeader>
           <TextMicro strong>Dimension</TextMicro>
           <TextMicro

--- a/src/components/line/popover/dimensions.test.js
+++ b/src/components/line/popover/dimensions.test.js
@@ -7,7 +7,8 @@ import {
   makeTestChart,
   renderWithChart,
 } from "@jest/testUtilities"
-import Dimensions from "./dimensions"
+import Dimensions, { rowFlavours } from "./dimensions"
+import { popoverGridColumns } from "./layout"
 
 const loadLinePayload = async (chart, ids, rows) => {
   const payload = makeHeatmapPayload(ids, rows)
@@ -67,5 +68,69 @@ describe("line popover Dimensions", () => {
 
     expect(screen.getByText(/more values/)).toBeInTheDocument()
     expect(screen.getAllByTestId("chartPopover-dimension")).toHaveLength(10)
+  })
+
+  it("uses fixed compact side columns for regular value popovers", async () => {
+    const ids = ["very-long-dimension-name-that-should-not-expand-the-popover"]
+    const { chart } = makeTestChart({
+      attributes: {
+        chartType: "line",
+        groupBy: [],
+        selectedDimensions: [],
+        selectedLegendDimensions: [],
+      },
+    })
+
+    await loadLinePayload(chart, ids, [[1]])
+    chart.updateAttribute("hoverX", [1000, ids[0]])
+
+    renderWithChart(<Dimensions />, { chart })
+
+    expect(screen.getByTestId("chartPopover-grid")).toHaveStyle(
+      [
+        "grid-template-columns:",
+        `minmax(0,auto) ${popoverGridColumns.value} ${popoverGridColumns.anomaly}`,
+        popoverGridColumns.info,
+      ].join(" ")
+    )
+    expect(screen.getByTestId("chartPopover-dimensionNameCell")).toHaveStyle(
+      [
+        "max-width:",
+        `calc( 80vw - 32px - ${popoverGridColumns.value} - ${popoverGridColumns.anomaly} -`,
+        `${popoverGridColumns.info} )`,
+      ].join(" ")
+    )
+  })
+
+  it("uses the wider fixed info column for annotation popovers", async () => {
+    const ids = ["dim0"]
+    const { chart } = makeTestChart({
+      attributes: {
+        chartType: "line",
+        groupBy: [],
+        selectedDimensions: [],
+        selectedLegendDimensions: [],
+      },
+    })
+
+    await loadLinePayload(chart, ids, [[1]])
+    chart.updateAttribute("hoverX", [1000, rowFlavours.ANNOTATIONS])
+
+    renderWithChart(<Dimensions />, { chart })
+
+    expect(screen.getByTestId("chartPopover-grid")).toHaveStyle(
+      [
+        "grid-template-columns:",
+        `minmax(0,auto) ${popoverGridColumns.value} ${popoverGridColumns.anomaly}`,
+        popoverGridColumns.annotationsInfo,
+      ].join(" ")
+    )
+    expect(screen.getByTestId("chartPopover-dimensionNameCell")).toHaveStyle(
+      [
+        "max-width:",
+        `calc( 80vw - 32px - ${popoverGridColumns.value} - ${popoverGridColumns.anomaly} -`,
+        `${popoverGridColumns.annotationsInfo} )`,
+      ].join(" ")
+    )
   })
 })

--- a/src/components/line/popover/layout.js
+++ b/src/components/line/popover/layout.js
@@ -1,0 +1,6 @@
+export const popoverGridColumns = {
+  value: "64px",
+  anomaly: "56px",
+  info: "36px",
+  annotationsInfo: "70px",
+}

--- a/src/helpers/heatmap.js
+++ b/src/helpers/heatmap.js
@@ -37,7 +37,7 @@ export const makeGetColor = (chart, opacity = 1) => {
   const colors = getColors(opacity)
 
   if (!Number.isFinite(max) || max <= 0) {
-    return value => (value == null ? "transparent" : colors[0])
+    return value => (value == null || value === 0 ? "transparent" : colors[0])
   }
 
   const step = max / (colors.length - 1)
@@ -45,7 +45,7 @@ export const makeGetColor = (chart, opacity = 1) => {
     .domain(Array.from({ length: colors.length - 1 }, (_, i) => i * step))
     .range(colors)
 
-  return value => (value == null ? "transparent" : getLinearColor(value))
+  return value => (value == null || value === 0 ? "transparent" : getLinearColor(value))
 }
 
 export const useGetColor = (opacity = 1) => {

--- a/src/helpers/heatmap.test.js
+++ b/src/helpers/heatmap.test.js
@@ -125,9 +125,9 @@ describe("heatmap utilities", () => {
       expect(getColor(undefined)).toBe("transparent")
     })
 
-    it("returns color for zero value", () => {
+    it("returns transparent for zero value", () => {
       const getColor = makeGetColor(mockChart)
-      expect(getColor(0)).toMatch(/rgb/)
+      expect(getColor(0)).toBe("transparent")
     })
 
     it("uses the low-end color when the heatmap max is zero", () => {
@@ -135,7 +135,7 @@ describe("heatmap utilities", () => {
 
       const getColor = makeGetColor(mockChart)
 
-      expect(getColor(0)).toBe("rgba(62, 73, 137, 1)")
+      expect(getColor(0)).toBe("transparent")
       expect(getColor(null)).toBe("transparent")
       expect(getColor(undefined)).toBe("transparent")
     })

--- a/src/sdk/makeChart/makeDimensions.js
+++ b/src/sdk/makeChart/makeDimensions.js
@@ -221,7 +221,7 @@ export default (chart, sdk) => {
         )
 
         if (prefix === newPrefix)
-          chart.setAttribute("heatmapType", heatmapTypes[prefix] || heatmapTypes.incremental)
+          chart.setAttribute("heatmapType", heatmapTypes[prefix] || heatmapTypes.default)
 
         prefix = newPrefix
       }
@@ -414,7 +414,7 @@ export default (chart, sdk) => {
     value = value !== null && typeof value === "object" ? value[valueKey] : value
     value = allowNull && value === null ? value : abs ? Math.abs(value) : value
 
-    if (incrementable && isIncremental(chart)) {
+    if (valueKey === "value" && incrementable && isIncremental(chart)) {
       let index = chart.getDimensionIds().findIndex(dimId => dimId === id)
 
       if (index === -1) return value

--- a/src/sdk/makeChart/makeDimensions.test.js
+++ b/src/sdk/makeChart/makeDimensions.test.js
@@ -818,6 +818,7 @@ describe("makeDimensions heatmap bucket ordering", () => {
     const chart = makeHeatmapChart(["bucket_+Inf", "bucket_1024", "bucket_2048"])
 
     expect(chart.getHeatmapSortedIds()).toEqual(["bucket_1024", "bucket_2048", "bucket_+Inf"])
+    expect(chart.getAttribute("heatmapType")).toBe("default")
     expect(chart.getHeatmapScale()).toBe("binary")
     expect(chart.getHeatmapYIndex("bucket_1024")).toBe(0)
     expect(chart.getDimensionIndex("bucket_1024")).toBe(1)
@@ -872,7 +873,37 @@ describe("makeDimensions heatmap bucket ordering", () => {
     expect(chart.getHeatmapYIndex("6")).toBe(-1)
   })
 
-  it("crops incremental heatmap edges using displayed bucket deltas", async () => {
+  it("keeps non-monotonic prefixed heatmap buckets as raw values", async () => {
+    const ids = ["bucket_0.025", "bucket_0.05"]
+    const chart = makeHeatmapChart(ids)
+
+    await loadHeatmapPayload(chart, ids, [[0.0212577, 0]])
+
+    const row = chart.getPayload().all[0]
+
+    expect(chart.getAttribute("heatmapType")).toBe("default")
+    expect(chart.getRowDimensionValue("bucket_0.025", row, { allowNull: true })).toBe(0.0212577)
+    expect(chart.getRowDimensionValue("bucket_0.05", row, { allowNull: true })).toBe(0)
+  })
+
+  it("does not subtract anomaly rates for explicit incremental heatmaps", async () => {
+    const ids = ["bucket_1", "bucket_2"]
+    const chart = makeHeatmapChart(ids)
+    const payload = makeHeatmapPayload(ids, [[10, 15]])
+    payload.result.data[0][1] = [10, 5, 0]
+    payload.result.data[0][2] = [15, 2, 0]
+
+    chart.doneFetch(payload)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    chart.setAttribute("heatmapType", "incremental")
+
+    const row = chart.getPayload().all[0]
+
+    expect(chart.getRowDimensionValue("bucket_2", row)).toBe(5)
+    expect(chart.getRowDimensionValue("bucket_2", row, { valueKey: "arp" })).toBe(2)
+  })
+
+  it("crops prefixed heatmap edges using raw bucket values", async () => {
     const ids = [
       "bucket_0",
       "bucket_1",
@@ -885,11 +916,11 @@ describe("makeDimensions heatmap bucket ordering", () => {
     const chart = makeHeatmapChart(ids)
 
     await loadHeatmapPayload(chart, ids, [
-      [0, 0, 1, 1, 3, 3, 3],
-      [0, 0, 0, 0, 3, 3, 3],
+      [0, 0, 1, 0, 3, 0, 0],
+      [0, 0, 0, 0, 3, 0, 0],
     ])
 
-    expect(chart.getAttribute("heatmapType")).toBe("incremental")
+    expect(chart.getAttribute("heatmapType")).toBe("default")
     expect(chart.getVisibleHeatmapIds()).toEqual([
       "bucket_1",
       "bucket_2",


### PR DESCRIPTION
## Summary

- use response `view.dimensions.sts` values for window min/avg/max/anomaly-rate chart-values stats, with a per-render value cache for remaining computed stats
- constrain the expanded chart-values drawer so the table owns vertical scrolling and avoids the extra outer scrollbar
- make popover value/anomaly/info columns fixed and compact, leaving remaining width to the dimension name
- treat prefixed heatmap buckets as raw values by default and only apply incremental subtraction to the main value channel
- render exact zero heatmap cells as transparent so all-zero heatmaps stay visually dim

## Testing

- `yarn test --runInBand --coverage=false`
- `./node_modules/.bin/eslint src/components/drawer/dimensions/columns.js src/components/drawer/dimensions/index.js src/components/drawer/dimensions/index.test.js src/components/drawer/dimensions/useDimensionValueCache.js src/components/drawer/dimensions/useDimensionValueCache.test.js src/components/drawer/index.js src/components/drawer/index.test.js src/components/line/popover/dimension.js src/components/line/popover/dimensions.js src/components/line/popover/dimensions.test.js src/components/line/popover/layout.js src/helpers/heatmap.js src/helpers/heatmap.test.js src/sdk/makeChart/makeDimensions.js src/sdk/makeChart/makeDimensions.test.js`
- `yarn build`
