### PR TITLE
Reuse Dygraph line chart data structures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "6.12.5",
+  "version": "6.12.6",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",

--- a/src/chartLibraries/dygraph/index.js
+++ b/src/chartLibraries/dygraph/index.js
@@ -19,12 +19,14 @@ import makeOverlays from "./overlays"
 import crosshair from "./crosshair"
 import { makeDivergingStackedDataHandler } from "./divergingStack"
 import makeDygraphWithoutLegend from "./makeDygraph"
+import { makeReusableLineDataHandler } from "./reusableLineDataHandler"
 
 const touchEvents = ["touchstart", "touchmove", "touchend"]
 
 export default (sdk, chart) => {
   const chartUI = makeChartUI(sdk, chart)
   const DivergingStackedDataHandler = makeDivergingStackedDataHandler(chart)
+  const ReusableLineDataHandler = makeReusableLineDataHandler()
   let dygraph = null
   let listeners = []
   let navigation = null
@@ -286,6 +288,7 @@ export default (sdk, chart) => {
       ...defaultOptions,
       strokeWidth: 1.5,
       fillAlpha: 0.2,
+      dataHandler: ReusableLineDataHandler,
     },
     stacked: {
       ...defaultOptions,

--- a/src/chartLibraries/dygraph/reusableLineDataHandler.js
+++ b/src/chartLibraries/dygraph/reusableLineDataHandler.js
@@ -1,0 +1,134 @@
+import Dygraph from "dygraphs"
+
+const haveSameLabels = (left, right) =>
+  left?.length === right?.length && left.every((label, index) => label === right[index])
+
+const haveUniqueLabels = labels => new Set(labels).size === labels.length
+
+const updateSeries = (series, rawData, seriesIndex, logScale) => {
+  for (let rowIndex = 0; rowIndex < rawData.length; rowIndex++) {
+    const row = rawData[rowIndex]
+    let value = row[seriesIndex]
+
+    if (logScale && value <= 0) value = null
+
+    const item = series[rowIndex]
+    item[0] = row[0]
+    item[1] = value
+  }
+}
+
+const makeSeries = (rawData, seriesIndex, logScale) => {
+  const series = new Array(rawData.length)
+
+  for (let rowIndex = 0; rowIndex < rawData.length; rowIndex++) {
+    const row = rawData[rowIndex]
+    let value = row[seriesIndex]
+
+    if (logScale && value <= 0) value = null
+    series[rowIndex] = [row[0], value]
+  }
+
+  return series
+}
+
+const updatePoints = (points, series) => {
+  for (let pointIndex = 0; pointIndex < series.length; pointIndex++) {
+    const item = series[pointIndex]
+    const point = points[pointIndex]
+
+    point.xval = item[0]
+    point.yval = item[1] === null ? null : item[1]
+    if ("annotation" in point) delete point.annotation
+  }
+}
+
+const makePoints = (series, setName, boundaryIdStart) => {
+  const points = new Array(series.length)
+
+  for (let pointIndex = 0; pointIndex < series.length; pointIndex++) {
+    const item = series[pointIndex]
+
+    points[pointIndex] = {
+      x: NaN,
+      y: NaN,
+      xval: item[0],
+      yval: item[1] === null ? null : item[1],
+      name: setName,
+      idx: pointIndex + boundaryIdStart,
+      canvasx: NaN,
+      canvasy: NaN,
+    }
+  }
+
+  return points
+}
+
+export const makeReusableLineDataHandler = () => {
+  const DefaultHandler = Dygraph.DataHandlers?.DefaultHandler
+  if (!DefaultHandler) return null
+
+  let labels
+  let rowCount
+  let reusable = false
+  let seriesByIndex = []
+  let pointsByName = new Map()
+
+  const reset = (nextLabels, nextRowCount) => {
+    labels = nextLabels.slice()
+    rowCount = nextRowCount
+    reusable = haveUniqueLabels(nextLabels)
+    seriesByIndex = []
+    pointsByName = new Map()
+  }
+
+  return class ReusableLineDataHandler extends DefaultHandler {
+    extractSeries(rawData, seriesIndex, options) {
+      const nextLabels = options.get("labels")
+
+      if (
+        seriesIndex === 1 &&
+        (!haveSameLabels(labels, nextLabels) || rowCount !== rawData.length)
+      ) {
+        reset(nextLabels, rawData.length)
+      }
+
+      if (!reusable) return super.extractSeries(rawData, seriesIndex, options)
+
+      const seriesLabel = nextLabels[seriesIndex]
+      const logScale = options.getForSeries("logscale", seriesLabel)
+      let series = seriesByIndex[seriesIndex]
+
+      if (!series) {
+        series = makeSeries(rawData, seriesIndex, logScale)
+        seriesByIndex[seriesIndex] = series
+      } else {
+        updateSeries(series, rawData, seriesIndex, logScale)
+      }
+
+      return series
+    }
+
+    seriesToPoints(series, setName, boundaryIdStart) {
+      if (!reusable) return super.seriesToPoints(series, setName, boundaryIdStart)
+
+      const cached = pointsByName.get(setName)
+      let points
+
+      if (
+        cached &&
+        cached.boundaryIdStart === boundaryIdStart &&
+        cached.points.length === series.length
+      ) {
+        points = cached.points
+        updatePoints(points, series)
+      } else {
+        points = makePoints(series, setName, boundaryIdStart)
+        pointsByName.set(setName, { boundaryIdStart, points })
+      }
+
+      this.onPointsCreated_(series, points)
+      return points
+    }
+  }
+}

--- a/src/chartLibraries/dygraph/reusableLineDataHandler.test.js
+++ b/src/chartLibraries/dygraph/reusableLineDataHandler.test.js
@@ -20,7 +20,16 @@ const makeDygraph = (data, options = {}) => {
 const snapshot = dygraph => ({
   series: dygraph.rolledSeries_.slice(1).map(series => series.map(item => [...item])),
   points: dygraph.layout_.points.map(points =>
-    points.map(({ xval, yval, name, idx }) => ({ xval, yval, name, idx }))
+    points.map(({ x, y, xval, yval, name, idx, canvasx, canvasy }) => ({
+      x,
+      y,
+      xval,
+      yval,
+      name,
+      idx,
+      canvasx,
+      canvasy,
+    }))
   ),
   xRange: dygraph.xAxisRange(),
   yRange: dygraph.yAxisRange(),
@@ -75,6 +84,43 @@ describe("reusable line data handler", () => {
       { xval: 2000, yval: 5, name: "first", idx: 0 },
       { xval: 3000, yval: 7, name: "first", idx: 1 },
     ])
+  })
+
+  it("overwrites corrected historical values in reused structures", () => {
+    const labels = ["time", "first", "second"]
+    const initialData = [
+      [1000, 1, 10],
+      [2000, 2, 20],
+      [3000, 3, 30],
+    ]
+    const reference = makeDygraph(initialData, { labels })
+    const candidate = makeDygraph(initialData, {
+      labels,
+      dataHandler: makeReusableLineDataHandler(),
+    })
+    const firstSeries = candidate.rolledSeries_[1]
+    const firstPair = firstSeries[0]
+    const firstPoints = candidate.layout_.points[0]
+    const firstPoint = firstPoints[0]
+    const correctedData = [
+      [1000, 11, 110],
+      [2000, null, 220],
+      [3000, 33, 330],
+    ]
+
+    reference.updateOptions({ file: correctedData, labels })
+    candidate.updateOptions({ file: correctedData, labels })
+
+    expect(candidate.rolledSeries_[1]).toBe(firstSeries)
+    expect(candidate.rolledSeries_[1][0]).toBe(firstPair)
+    expect(candidate.layout_.points[0]).toBe(firstPoints)
+    expect(candidate.layout_.points[0][0]).toBe(firstPoint)
+    expect(candidate.rolledSeries_[1]).toEqual([
+      [1000, 11],
+      [2000, null],
+      [3000, 33],
+    ])
+    expect(snapshot(candidate)).toEqual(snapshot(reference))
   })
 
   it("rebuilds cached structures when the row shape changes", () => {

--- a/src/chartLibraries/dygraph/reusableLineDataHandler.test.js
+++ b/src/chartLibraries/dygraph/reusableLineDataHandler.test.js
@@ -1,0 +1,219 @@
+import Dygraph from "dygraphs"
+import { makeReusableLineDataHandler } from "./reusableLineDataHandler"
+
+const dygraphs = []
+
+const makeDygraph = (data, options = {}) => {
+  const element = document.createElement("div")
+  Object.defineProperties(element, {
+    clientWidth: { value: 800 },
+    clientHeight: { value: 400 },
+  })
+  element.style.padding = "0px"
+  document.body.appendChild(element)
+
+  const dygraph = new Dygraph(element, data, options)
+  dygraphs.push(dygraph)
+  return dygraph
+}
+
+const snapshot = dygraph => ({
+  series: dygraph.rolledSeries_.slice(1).map(series => series.map(item => [...item])),
+  points: dygraph.layout_.points.map(points =>
+    points.map(({ xval, yval, name, idx }) => ({ xval, yval, name, idx }))
+  ),
+  xRange: dygraph.xAxisRange(),
+  yRange: dygraph.yAxisRange(),
+})
+
+describe("reusable line data handler", () => {
+  afterEach(() => {
+    dygraphs.forEach(dygraph => dygraph.destroy())
+    dygraphs.length = 0
+    document.body.innerHTML = ""
+  })
+
+  it("reuses extracted pairs and point objects for compatible updates", () => {
+    const labels = ["time", "first", "second"]
+    const dataHandler = makeReusableLineDataHandler()
+    const dygraph = makeDygraph(
+      [
+        [1000, 1, 2],
+        [2000, 3, 4],
+      ],
+      { labels, dataHandler }
+    )
+    const firstSeries = dygraph.rolledSeries_[1]
+    const firstPair = firstSeries[0]
+    const firstPoints = dygraph.layout_.points[0]
+    const firstPoint = firstPoints[0]
+
+    dygraph.updateOptions({
+      file: [
+        [2000, 5, 6],
+        [3000, 7, 8],
+      ],
+      labels,
+    })
+
+    expect(dygraph.rolledSeries_[1]).toBe(firstSeries)
+    expect(dygraph.rolledSeries_[1][0]).toBe(firstPair)
+    expect(dygraph.layout_.points[0]).toBe(firstPoints)
+    expect(dygraph.layout_.points[0][0]).toBe(firstPoint)
+    expect(dygraph.rolledSeries_[1]).toEqual([
+      [2000, 5],
+      [3000, 7],
+    ])
+    expect(
+      dygraph.layout_.points[0].map(({ xval, yval, name, idx }) => ({
+        xval,
+        yval,
+        name,
+        idx,
+      }))
+    ).toEqual([
+      { xval: 2000, yval: 5, name: "first", idx: 0 },
+      { xval: 3000, yval: 7, name: "first", idx: 1 },
+    ])
+  })
+
+  it("rebuilds cached structures when the row shape changes", () => {
+    const labels = ["time", "value"]
+    const dygraph = makeDygraph(
+      [
+        [1000, 1],
+        [2000, 2],
+      ],
+      { labels, dataHandler: makeReusableLineDataHandler() }
+    )
+    const firstSeries = dygraph.rolledSeries_[1]
+    const firstPoint = dygraph.layout_.points[0][0]
+
+    dygraph.updateOptions({
+      file: [
+        [1000, 3],
+        [2000, 4],
+        [3000, 5],
+      ],
+      labels,
+    })
+
+    expect(dygraph.rolledSeries_[1]).not.toBe(firstSeries)
+    expect(dygraph.layout_.points[0][0]).not.toBe(firstPoint)
+    expect(dygraph.rolledSeries_[1]).toEqual([
+      [1000, 3],
+      [2000, 4],
+      [3000, 5],
+    ])
+  })
+
+  it("rebuilds cached structures when labels are reordered", () => {
+    const dygraph = makeDygraph(
+      [
+        [1000, 1, 2],
+        [2000, 3, 4],
+      ],
+      {
+        labels: ["time", "first", "second"],
+        dataHandler: makeReusableLineDataHandler(),
+      }
+    )
+    const firstSeries = dygraph.rolledSeries_[1]
+    const firstPoint = dygraph.layout_.points[0][0]
+
+    dygraph.updateOptions({
+      file: [
+        [1000, 2, 1],
+        [2000, 4, 3],
+      ],
+      labels: ["time", "second", "first"],
+    })
+
+    expect(dygraph.rolledSeries_[1]).not.toBe(firstSeries)
+    expect(dygraph.layout_.points[0][0]).not.toBe(firstPoint)
+    expect(dygraph.layout_.points[0][0].name).toBe("second")
+  })
+
+  it("does not retain removed annotations on reused points", () => {
+    const labels = ["time", "value"]
+    const dygraph = makeDygraph([[1000, 1]], {
+      labels,
+      dataHandler: makeReusableLineDataHandler(),
+    })
+
+    dygraph.setAnnotations([{ series: "value", x: 1000, shortText: "A" }])
+    const point = dygraph.layout_.points[0][0]
+    expect(point.annotation).toBeTruthy()
+
+    dygraph.setAnnotations([])
+
+    expect(dygraph.layout_.points[0][0]).toBe(point)
+    expect(point.annotation).toBeUndefined()
+  })
+
+  it("rebuilds points when the visible boundary changes", () => {
+    const labels = ["time", "value"]
+    const dygraph = makeDygraph(
+      [
+        [1000, 1],
+        [2000, 2],
+        [3000, 3],
+        [4000, 4],
+        [5000, 5],
+        [6000, 6],
+      ],
+      {
+        labels,
+        dateWindow: [2000, 3000],
+        dataHandler: makeReusableLineDataHandler(),
+      }
+    )
+    const series = dygraph.rolledSeries_[1]
+    const point = dygraph.layout_.points[0][0]
+
+    dygraph.updateOptions({ dateWindow: [3000, 4000] })
+
+    expect(dygraph.rolledSeries_[1]).toBe(series)
+    expect(dygraph.layout_.points[0][0]).not.toBe(point)
+    expect(dygraph.layout_.points[0].map(({ xval, idx }) => ({ xval, idx }))).toEqual([
+      { xval: 2000, idx: 1 },
+      { xval: 3000, idx: 2 },
+      { xval: 4000, idx: 3 },
+      { xval: 5000, idx: 4 },
+    ])
+  })
+
+  it("matches the default handler for gaps, log scales, rolling, and zoom", () => {
+    const labels = ["time", "first", "second"]
+    const initialData = [
+      [1000, -1, null],
+      [2000, 2, NaN],
+      [3000, 0, 4],
+      [4000, 8, 16],
+    ]
+    const options = {
+      labels,
+      logscale: true,
+      rollPeriod: 2,
+      dateWindow: [1500, 3500],
+    }
+    const reference = makeDygraph(initialData, options)
+    const candidate = makeDygraph(initialData, {
+      ...options,
+      dataHandler: makeReusableLineDataHandler(),
+    })
+
+    expect(snapshot(candidate)).toEqual(snapshot(reference))
+
+    const nextData = [
+      [2000, 1, 2],
+      [3000, null, 4],
+      [4000, 8, 0],
+      [5000, 16, 32],
+    ]
+    reference.updateOptions({ file: nextData, labels })
+    candidate.updateOptions({ file: nextData, labels })
+
+    expect(snapshot(candidate)).toEqual(snapshot(reference))
+  })
+})


### PR DESCRIPTION
## What changed

- add a Dygraphs line-data handler that reuses the allocated series arrays, point arrays, and point objects across compatible updates
- overwrite every timestamp and value in those reusable containers from every new response
- discard the reusable containers when labels, label order, row count, or the visible point boundary changes
- fall back to Dygraphs' default handler when labels are not unique
- keep stacked and stacked-bar charts on their existing data handler
- add parity and lifecycle coverage for compatible updates, historical corrections, shape changes, label reordering, annotations, zoom boundaries, gaps, log scale, and rolling

## Root cause

Dygraphs' default line handler reconstructs extracted `[x, y]` pairs and point records on every data update. A chart with thousands of dimensions therefore creates millions of short-lived arrays and objects per refresh, increasing preparation time, heap growth, and garbage-collection pressure even when the response shape is unchanged.

## Measured benefit

An isolated local preparation benchmark used the production CommonJS build on Node.js 22.22.2 with 6,000 dimensions × 297 timestamps (1,782,000 values). Both handlers were warmed first, all values changed before every sample, 20 samples per handler were run in alternating order, and explicit garbage collection preceded each sample.

The measured scope is exactly the stage changed by this PR: `extractSeries` plus `seriesToPoints`.

| Repeated compatible update | Dygraphs default | Reusable handler | Change |
| --- | ---: | ---: | ---: |
| Median preparation time | 102.5 ms | 49.3 ms | 51.9% lower; 2.08× faster |
| p95 preparation time | 121.8 ms | 66.2 ms | 45.6% lower |
| Median transient heap increase | 455.38 MiB | 0.09 MiB | 99.98% lower |
| p95 transient heap increase | 455.44 MiB | 0.13 MiB | 99.97% lower |

The heap figures measure additional allocation during one update, not total retained chart heap. The reusable-handler baseline already contains the current chart structures.

The first render still constructs the arrays and point objects. These results apply to subsequent structurally compatible updates. They exclude response creation, SDK transformation, extrema and range calculation, layout, and canvas drawing; no end-to-end rendering percentage is claimed.

## What is reused — and what is not

This change reuses allocations, not data.

Every new response is still fully processed:

- every series and every row is traversed
- every reusable `[x, y]` pair receives the latest timestamp and value, including corrected historical values
- every reusable visible point receives the latest `xval` and `yval`
- Dygraphs recalculates ranges, normalized coordinates, and canvas coordinates from those new values

The handler does not cache query results, skip values, or keep previous values merely because the response shape is unchanged.

A response is structurally compatible only when:

- labels have exactly the same count, names, and order
- labels are unique
- the row count is unchanged
- a reused visible point array has the same starting boundary and length

If dimensions connect, disconnect, reconnect, or replicate and this changes the label sequence or row count, the reusable containers are discarded and rebuilt. If the structure stays the same but any current or historical values change, the containers are retained and every value is overwritten from the new response.

## Behavior and compatibility

This uses Dygraphs' supported public `dataHandler` extension point; it does not fork Dygraphs or mutate undocumented Dygraphs state.

Queries, payloads, chart results, line rendering, gaps, logarithmic scales, rolling windows, annotations, zoom behavior, and stacked-chart behavior remain unchanged. Structural incompatibility causes a safe rebuild; duplicate labels use Dygraphs' original handler.

## Validation

- 145 Jest suites passed
- 1,378 tests passed and 2 skipped
- focused handler suite: 7 tests passed
- same-label, same-row-count, same-timestamp historical corrections retain object identity while matching the stock handler's values, ranges, normalized coordinates, and canvas coordinates
- focused ESLint passed
- CommonJS build compiled 465 files
- ES-module build compiled 465 files
- installed into Cloud Frontend and manually exercised on a high-cardinality dashboard
