### PR TITLE
Fix chart popover dimension windowing

### DIFF
--- a/src/components/bars/dimensions.js
+++ b/src/components/bars/dimensions.js
@@ -2,6 +2,7 @@ import React, { useMemo, memo } from "react"
 import styled from "styled-components"
 import { useChart, useAttributeValue, usePayload } from "@/components/provider"
 import { TextMicro, TextNano } from "@netdata/netdata-ui"
+import getWindowRange from "@/helpers/getWindowRange"
 import Dimension from "./dimension"
 
 const Grid = styled.div`
@@ -24,27 +25,6 @@ const emptyArray = [null, null]
 const getMaxDimensions = height => {
   const maxDimensions = Math.round((height - 70) / 18)
   return maxDimensions < 2 ? 2 : maxDimensions
-}
-const getHalf = height => getMaxDimensions(height) / 2
-
-const getFrom = (total, index, height) => {
-  if (total < getMaxDimensions(height)) return 0
-
-  if (index < getHalf(height)) return 0
-
-  if (index > total - getHalf(height)) return index - (getHalf(height) + (total - index))
-
-  return index - getHalf(height)
-}
-
-const getTo = (total, index, height) => {
-  if (total < getMaxDimensions(height)) return total
-
-  if (index < getHalf(height)) return index + getHalf(height) + (getHalf(height) - index)
-
-  if (index > total - getHalf(height)) return total
-
-  return index + getHalf(height)
 }
 
 export const rowFlavours = {
@@ -81,8 +61,11 @@ const Dimensions = ({ height }) => {
 
     const total = dimensionIds.length
 
-    const from = Math.floor(getFrom(total, rowIndex, height))
-    const to = Math.ceil(getTo(total, rowIndex, height))
+    const { from, to } = getWindowRange({
+      total,
+      index: rowIndex,
+      limit: getMaxDimensions(height),
+    })
     const ids = dimensionIds.slice(from, to)
 
     return [from, to, total, ids]

--- a/src/components/line/popover/dimensions.js
+++ b/src/components/line/popover/dimensions.js
@@ -2,6 +2,7 @@ import React, { useMemo, memo } from "react"
 import styled from "styled-components"
 import { Flex, TextMicro, TextNano } from "@netdata/netdata-ui"
 import { useChart, useAttributeValue } from "@/components/provider"
+import getWindowRange from "@/helpers/getWindowRange"
 import Header from "./header"
 import Dimension from "./dimension"
 import {
@@ -43,27 +44,6 @@ const getMaxDimensions = () => {
   const maxDimensions = Math.floor((window.innerHeight - 500) / 15) || 16
   return maxDimensions < 5 ? 5 : maxDimensions > 10 ? 10 : 10
 }
-const getHalf = () => getMaxDimensions() / 2
-
-const getFrom = (total, index) => {
-  if (total < getMaxDimensions()) return 0
-
-  if (index < getHalf()) return 0
-
-  if (index > total - getHalf()) return index - (getHalf() + (total - index))
-
-  return index - getHalf()
-}
-
-const getTo = (total, index) => {
-  if (total < getMaxDimensions()) return total
-
-  if (index < getHalf()) return index + getHalf() + (getHalf() - index)
-
-  if (index > total - getHalf()) return total
-
-  return index + getHalf()
-}
 
 export const rowFlavours = {
   ANOMALY_RATE: "ANOMALY_RATE",
@@ -97,8 +77,11 @@ const Dimensions = () => {
     const total = dimensionIds.length
     if (isHeatmap) return [0, total, total, dimensionIds]
 
-    const from = Math.floor(getFrom(total, rowIndex))
-    const to = Math.ceil(getTo(total, rowIndex))
+    const { from, to } = getWindowRange({
+      total,
+      index: rowIndex,
+      limit: getMaxDimensions(),
+    })
     const ids = dimensionIds.slice(from, to)
 
     return [from, to, total, ids]

--- a/src/components/line/popover/dimensions.test.js
+++ b/src/components/line/popover/dimensions.test.js
@@ -86,6 +86,32 @@ describe("line popover Dimensions", () => {
     expect(screen.getAllByTestId("chartPopover-dimension")).toHaveLength(10)
   })
 
+  it("keeps the complete list when the highlighted row is in the lower half", async () => {
+    const ids = Array.from({ length: 10 }, (_, index) => `dim${index}`)
+    const { chart } = makeTestChart({
+      attributes: {
+        chartType: "line",
+        groupBy: [],
+        selectedDimensions: [],
+        selectedLegendDimensions: [],
+      },
+    })
+
+    await loadLinePayload(
+      chart,
+      ids,
+      [ids.map((_, index) => index)]
+    )
+    chart.updateAttribute("hoverX", [1000, "dim2"])
+
+    renderWithChart(<Dimensions />, { chart })
+
+    expect(screen.queryByText(/more values/)).not.toBeInTheDocument()
+    expect(screen.getAllByTestId("chartDimensions-name").map(node => node.textContent)).toEqual(
+      [...ids].reverse()
+    )
+  })
+
   it("uses fixed compact side columns for regular value popovers", async () => {
     const ids = ["very-long-dimension-name-that-should-not-expand-the-popover"]
     const { chart } = makeTestChart({

--- a/src/helpers/getWindowRange/index.js
+++ b/src/helpers/getWindowRange/index.js
@@ -1,0 +1,9 @@
+const getWindowRange = ({ total, index, limit }) => {
+  const size = Math.min(total, limit)
+  const centeredFrom = index - Math.floor(size / 2)
+  const from = Math.max(0, Math.min(centeredFrom, total - size))
+
+  return { from, to: from + size }
+}
+
+export default getWindowRange

--- a/src/helpers/getWindowRange/index.test.js
+++ b/src/helpers/getWindowRange/index.test.js
@@ -1,0 +1,16 @@
+import getWindowRange from "./index"
+
+describe("getWindowRange", () => {
+  test.each([
+    ["an empty list", 0, -1, 10, { from: 0, to: 0 }],
+    ["a list shorter than the limit", 4, 3, 10, { from: 0, to: 4 }],
+    ["a list equal to the limit", 10, 7, 10, { from: 0, to: 10 }],
+    ["the beginning of a longer list", 12, 0, 10, { from: 0, to: 10 }],
+    ["the middle of a longer list", 12, 6, 10, { from: 1, to: 11 }],
+    ["the end of a longer list", 12, 11, 10, { from: 2, to: 12 }],
+    ["a missing selected item", 12, -1, 10, { from: 0, to: 10 }],
+    ["an odd limit", 12, 6, 7, { from: 3, to: 10 }],
+  ])("returns the fixed-size range for %s", (_name, total, index, limit, expected) => {
+    expect(getWindowRange({ total, index, limit })).toEqual(expected)
+  })
+})


### PR DESCRIPTION
## Summary

- replace duplicated popover window arithmetic with one bounded shared helper
- use the same fixed-size window for line and bar dimension popovers
- cover empty, shorter, equal, longer, missing-selection, and odd-limit boundaries
- add a component regression for a highlighted row in the lower half of a full window

## Root cause

The previous end-window calculation could produce a negative start index. With 10 dimensions, a 10-row limit, and the highlighted dimension at sorted index 7, it calculated `from = -1`; `slice(-1, 10)` then rendered only the final dimension even though the complete ordered list was unchanged.

The duplicated bar implementation also rounded fractional boundaries outward for odd limits, which could render one row above the configured maximum.

## Behavior after this change

- the sorted dimension list remains unchanged for a fixed timestamp
- vertical hover movement only shifts the visible window and its hidden-above/hidden-below counters
- ranges are always non-negative, contiguous, and no larger than the configured limit
- lists at or below the limit are rendered completely

## Verification

- `yarn test --coverage --collectCoverageFrom=./src/**`: 146 suites passed; 1,387 tests passed; 2 skipped
- changed-file ESLint: passed
- CommonJS and ES module production builds: passed
- Chromium against the real `app.mem_page_faults` stacked chart: the same timestamp and 11-item ordering produced two correct 10-row windows, with exactly one item hidden above or below

## Scope

No payload, chart data, sorting, selection, or rendering-engine behavior changes.
