### PR TITLE
Fix chart playback recovery and frozen-window gaps

### DIFF
--- a/src/components/provider/selectors.test.js
+++ b/src/components/provider/selectors.test.js
@@ -1,5 +1,10 @@
 import { renderHook, act } from "@testing-library/react"
-import { makeHeatmapPayload, renderHookWithChart, makeTestChart } from "@jest/testUtilities"
+import {
+  loadHeatmapPayload,
+  makeHeatmapPayload,
+  renderHookWithChart,
+  makeTestChart,
+} from "@jest/testUtilities"
 import {
   useChart,
   useAttributeValue,
@@ -310,6 +315,24 @@ describe("Chart Provider Selectors", () => {
   })
 
   describe("display values", () => {
+    it("returns to the latest value when chart hover ends without a Dygraph mouseout", async () => {
+      const { chart, sdk } = makeTestChart()
+      await loadHeatmapPayload(chart, ["dim1"], [[50], [60]])
+
+      const { result } = renderHookWithChart(() => useLatestValue("dim1"), { chart })
+
+      act(() => {
+        chart.focus()
+        sdk.trigger("highlightHover", chart, 1000, "dim1")
+      })
+
+      expect(result.current).toBe(50)
+
+      act(() => chart.blur())
+
+      expect(result.current).toBe(60)
+    })
+
     it("refreshes latest values for successful fetches instead of render requests", () => {
       jest.useFakeTimers()
       const { chart } = makeTestChart()

--- a/src/components/useHover.js
+++ b/src/components/useHover.js
@@ -6,26 +6,43 @@ const useHover = ({ onHover, onBlur, isOut = defaultIsOut }, deps) => {
   const ref = useRef()
 
   useLayoutEffect(() => {
-    if (!ref.current) return
+    const element = ref.current
+    if (!element) return
 
     const mouseout = e => {
       let node = e.relatedTarget
 
-      while (node && node !== ref.current && isOut(node)) {
+      while (node && node !== element && isOut(node)) {
         node = node.parentElement
       }
 
-      if (node !== ref.current && isOut(node)) onBlur()
+      if (node !== element && isOut(node)) onBlur()
     }
 
-    ref.current.addEventListener("mouseover", onHover)
-    ref.current.addEventListener("mouseout", mouseout)
+    const reconcileHover = () => {
+      if (typeof element.matches !== "function") return
+
+      if (element.matches(":hover")) onHover()
+      else onBlur()
+    }
+
+    const visibilityChange = () => {
+      if (document.visibilityState !== "visible") return
+      if (typeof document.hasFocus === "function" && !document.hasFocus()) return
+
+      reconcileHover()
+    }
+
+    element.addEventListener("mouseover", onHover)
+    element.addEventListener("mouseout", mouseout)
+    window.addEventListener("focus", reconcileHover)
+    document.addEventListener("visibilitychange", visibilityChange)
 
     return () => {
-      if (!ref.current) return
-
-      ref.current.removeEventListener("mouseover", onHover)
-      ref.current.removeEventListener("mouseout", mouseout)
+      element.removeEventListener("mouseover", onHover)
+      element.removeEventListener("mouseout", mouseout)
+      window.removeEventListener("focus", reconcileHover)
+      document.removeEventListener("visibilitychange", visibilityChange)
     }
   }, [...deps, ref.current])
 

--- a/src/components/useHover.test.js
+++ b/src/components/useHover.test.js
@@ -136,10 +136,33 @@ describe("useHover", () => {
     const mouseoverHandler = addedCalls.find(call => call[0] === "mouseover")[1]
     const mouseoutHandler = addedCalls.find(call => call[0] === "mouseout")[1]
 
+    act(() => {
+      result.current.current = null
+    })
     unmount()
 
     expect(mockElement.removeEventListener).toHaveBeenCalledWith("mouseover", mouseoverHandler)
     expect(mockElement.removeEventListener).toHaveBeenCalledWith("mouseout", mouseoutHandler)
+  })
+
+  it("reconciles hover state from the DOM when the window regains focus", () => {
+    mockElement.matches = jest.fn(() => false)
+    const { result, rerender } = renderHook(() =>
+      useHover({ onHover: mockOnHover, onBlur: mockOnBlur }, [])
+    )
+
+    act(() => {
+      result.current.current = mockElement
+    })
+    rerender()
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"))
+    })
+
+    expect(mockElement.matches).toHaveBeenCalledWith(":hover")
+    expect(mockOnBlur).toHaveBeenCalledTimes(1)
+    expect(mockOnHover).not.toHaveBeenCalled()
   })
 
   it("uses default isOut function when not provided", () => {

--- a/src/sdk/makeChart/api/helpers.js
+++ b/src/sdk/makeChart/api/helpers.js
@@ -36,8 +36,11 @@ export const getLiveFetchBefore = ({
   hovering,
   fetchStartedAt,
   viewUpdateEvery,
+  liveRequestBefore,
 }) => {
   if (after > 0) return null
+  if (typeof liveRequestBefore === "number" && isFinite(liveRequestBefore))
+    return Math.ceil(liveRequestBefore)
   if (viewUpdateEvery && viewUpdateEvery > Math.abs(after)) return null
 
   return hovering && renderedAt ? Math.ceil(renderedAt / 1000) : Math.ceil(fetchStartedAt / 1000)
@@ -60,6 +63,7 @@ export const getChartPayload = (chart, attrs = {}) => {
     chartLibrary,
     points: customPoints,
     viewUpdateEvery,
+    liveRequestBefore,
   } = { ...chart.getAttributes(), ...attrs }
 
   const pointsMultiplier =
@@ -73,6 +77,7 @@ export const getChartPayload = (chart, attrs = {}) => {
     hovering,
     fetchStartedAt,
     viewUpdateEvery,
+    liveRequestBefore,
   })
 
   const afterBefore =

--- a/src/sdk/makeChart/api/helpers.test.js
+++ b/src/sdk/makeChart/api/helpers.test.js
@@ -168,6 +168,19 @@ describe("API helpers", () => {
 
       expect(result).toBe(null)
     })
+
+    it("uses an explicit live request anchor for a frozen view update window", () => {
+      const result = getLiveFetchBefore({
+        after: -300,
+        renderedAt: null,
+        hovering: false,
+        fetchStartedAt: 1000500,
+        viewUpdateEvery: 600,
+        liveRequestBefore: 900.25,
+      })
+
+      expect(result).toBe(901)
+    })
   })
 
   describe("getChartPayload", () => {
@@ -289,6 +302,31 @@ describe("API helpers", () => {
 
       expect(result.after).toBe(701)
       expect(result.before).toBe(1001)
+    })
+
+    it("keeps an explicit live request anchor when chart state changes", () => {
+      const { chart } = makeTestChart({
+        attributes: {
+          after: -300,
+          before: 0,
+          groupingMethod: "average",
+          groupingTime: "auto",
+          renderedAt: 1200000,
+          hovering: true,
+          fetchStartedAt: 1200500,
+          chartType: "line",
+          pixelsPerPoint: 4,
+          chartLibrary: "dygraph",
+          viewUpdateEvery: 600,
+        },
+      })
+
+      chart.getUI().getChartWidth = () => 800
+
+      const result = getChartPayload(chart, { liveRequestBefore: 1000 })
+
+      expect(result.after).toBe(700)
+      expect(result.before).toBe(1000)
     })
 
     it("uses different multiplier for multiBar", () => {

--- a/src/sdk/makeChart/index.js
+++ b/src/sdk/makeChart/index.js
@@ -229,7 +229,10 @@ export default ({
 
   node.deactivate = () => {
     if (!node) return
+
     node.updateAttribute("active", false)
+    if (node.getAttribute("focused")) node.blur()
+
     sdk.trigger("active", node, false)
     node.trigger("active", false)
   }
@@ -409,6 +412,8 @@ export default ({
   const destroy = () => {
     if (!node) return
 
+    node.updateAttribute("active", false)
+    if (node.getAttribute("focused")) node.blur()
     if (executeLatest) executeLatest.clear()
 
     node.destroy()

--- a/src/sdk/makeChart/index.test.js
+++ b/src/sdk/makeChart/index.test.js
@@ -153,6 +153,28 @@ describe("makeChart", () => {
     expect(chart.getAttribute("active")).toBe(false)
   })
 
+  it("deactivate releases an active hover", () => {
+    chart.focus()
+
+    chart.deactivate()
+
+    expect(chart.getAttribute("focused")).toBe(false)
+    expect(chart.getAttribute("hovering")).toBe(false)
+    expect(sdk.getRoot().getAttribute("hovering")).toBe(false)
+  })
+
+  it("destroy releases an active hover", () => {
+    jest.useFakeTimers()
+    chart.focus()
+
+    chart.destroy()
+
+    expect(sdk.getRoot().getAttribute("hovering")).toBe(false)
+    sdk.unregister("play")
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
   it("getUnits returns units from attributes", () => {
     chart.updateAttribute("units", "GB")
     const units = chart.getUnits()

--- a/src/sdk/makeChart/makeDataFetch.js
+++ b/src/sdk/makeChart/makeDataFetch.js
@@ -96,10 +96,44 @@ export default chart => {
     return data?.length || 0
   }
 
-  chart.doneFetch = (nextRawPayload, { liveAnchor } = {}) => {
+  const getFrozenWindowEnd = () => {
+    const { after, hovering } = chart.getAttributes()
+    if (after > 0) return null
+
+    const paused = chart.getRoot?.()?.getAttribute?.("paused")
+    if (!hovering && !paused) return null
+
+    const windowEnd = chart.getDateWindow?.()?.[1]
+    return typeof windowEnd === "number" && isFinite(windowEnd) ? windowEnd : null
+  }
+
+  const isFrozenAtAnotherAnchor = requestAnchor => {
+    if (
+      !chart.getAttribute("loaded") ||
+      typeof requestAnchor !== "number" ||
+      !isFinite(requestAnchor)
+    )
+      return false
+
+    const frozenWindowEnd = getFrozenWindowEnd()
+    if (frozenWindowEnd === null) return false
+
+    return Math.ceil(frozenWindowEnd / 1000) * 1000 !== requestAnchor
+  }
+
+  chart.doneFetch = (nextRawPayload, { liveAnchor, requestAnchor = liveAnchor } = {}) => {
     chart.backoffMs = 0
 
     setTimeout(() => {
+      if (isFrozenAtAnotherAnchor(requestAnchor)) {
+        chart.updateAttributes({
+          loading: false,
+          processing: false,
+        })
+        finishFetch()
+        return
+      }
+
       const { result, chartType, versions, title, ...restPayload } = camelizePayload(
         nextRawPayload,
         chart
@@ -213,10 +247,12 @@ export default chart => {
     failFetch = chart.failFetch,
     signal,
     params = {},
+    attrs,
   } = {}) => {
     if (!chart) return
 
     const options = {
+      ...(attrs && { attrs }),
       params,
       signal,
     }
@@ -249,6 +285,9 @@ export default chart => {
       loading: true,
       fetchStartedAt,
     })
+    const frozenWindowEnd = getFrozenWindowEnd()
+    const liveRequestBefore =
+      frozenWindowEnd === null ? undefined : Math.ceil(frozenWindowEnd / 1000)
     const { after, hovering, renderedAt, viewUpdateEvery } = chart.getAttributes()
     const fetchBefore = getLiveFetchBefore({
       after,
@@ -256,11 +295,18 @@ export default chart => {
       renderedAt,
       fetchStartedAt,
       viewUpdateEvery,
+      liveRequestBefore,
     })
     const liveAnchor =
       typeof fetchBefore === "number" && isFinite(fetchBefore) && fetchBefore > 0
         ? fetchBefore * 1000
         : null
+    const requestAnchor =
+      after > 0
+        ? null
+        : (typeof fetchBefore === "number" && isFinite(fetchBefore)
+            ? fetchBefore
+            : Math.ceil(fetchStartedAt / 1000)) * 1000
 
     chart.cancelFetch()
     chart.trigger("startFetch")
@@ -272,9 +318,13 @@ export default chart => {
     abortController = new AbortController()
 
     return chart.baseFetch({
-      doneFetch: data => chart.doneFetch(data, { liveAnchor }),
+      doneFetch: data => chart.doneFetch(data, { liveAnchor, requestAnchor }),
       failFetch: chart.failFetch,
       signal: abortController.signal,
+      attrs:
+        typeof fetchBefore === "number" && isFinite(fetchBefore)
+          ? { liveRequestBefore: fetchBefore }
+          : undefined,
     })
   }
 

--- a/src/sdk/makeChart/makeDataFetch.test.js
+++ b/src/sdk/makeChart/makeDataFetch.test.js
@@ -17,6 +17,7 @@ const rawPayload = {
 
 describe("makeDataFetch", () => {
   let mockChart
+  let mockRoot
 
   beforeEach(() => {
     const attributes = {
@@ -27,6 +28,16 @@ describe("makeDataFetch", () => {
       title: null,
       loaded: false,
       initializedFilters: true,
+    }
+    const rootAttributes = {
+      paused: false,
+    }
+    mockRoot = {
+      getAttribute: jest.fn((name, fallback) => rootAttributes[name] ?? fallback),
+      updateAttribute: jest.fn((name, value) => {
+        rootAttributes[name] = value
+      }),
+      trigger: jest.fn(),
     }
 
     mockChart = {
@@ -46,9 +57,11 @@ describe("makeDataFetch", () => {
       getParent: jest.fn(() => ({
         updateAttribute: jest.fn(),
       })),
-      getRoot: jest.fn(() => ({
-        trigger: jest.fn(),
-      })),
+      getRoot: jest.fn(() => mockRoot),
+      getDateWindow: jest.fn(() => {
+        const anchor = attributes.renderedAt ?? attributes.liveAnchor ?? Date.now()
+        return [anchor + attributes.after * 1000, anchor]
+      }),
       getChart: jest.fn(() => Promise.resolve(rawPayload)),
       updateDimensions: jest.fn(),
       startAutofetch: jest.fn(),
@@ -153,6 +166,16 @@ describe("makeDataFetch", () => {
     })
   })
 
+  it("baseFetch forwards request attributes", async () => {
+    await mockChart.baseFetch({ attrs: { liveRequestBefore: 1000 } })
+
+    expect(mockChart.getChart).toHaveBeenCalledWith(mockChart, {
+      attrs: { liveRequestBefore: 1000 },
+      params: {},
+      signal: undefined,
+    })
+  })
+
   it("fetch updates loading state", () => {
     mockChart.fetch()
 
@@ -226,6 +249,103 @@ describe("makeDataFetch", () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(chart.getAttribute("liveAnchor")).toBe(1002000)
+  })
+
+  it("queries the visible window when fetching while paused", async () => {
+    mockChart.updateAttributes({
+      firstEntry: 1,
+      loaded: true,
+      liveAnchor: 1000000,
+      viewUpdateEvery: 600,
+    })
+    mockRoot.updateAttribute("paused", true)
+    global.Date.now.mockReturnValue(1200500)
+
+    await mockChart.fetch()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(mockChart.getChart).toHaveBeenCalledWith(
+      mockChart,
+      expect.objectContaining({
+        attrs: { liveRequestBefore: 1000 },
+      })
+    )
+    expect(mockChart.getAttribute("liveAnchor")).toBe(1000000)
+  })
+
+  it("discards a current-time response after the chart freezes on an older window", async () => {
+    mockChart.updateAttributes({
+      loaded: true,
+      liveAnchor: 1000000,
+      viewUpdateEvery: 600,
+    })
+    mockChart.doneFetch(rawPayload, {
+      liveAnchor: 1000000,
+      requestAnchor: 1000000,
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    const previousPayload = mockChart.getPayload()
+    mockChart.trigger.mockClear()
+
+    let resolveFetch
+    mockChart.getChart.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveFetch = resolve
+        })
+    )
+    global.Date.now.mockReturnValue(1200500)
+
+    const fetch = mockChart.fetch()
+    mockChart.updateAttributes({
+      hovering: true,
+      renderedAt: 1000000,
+    })
+    resolveFetch({
+      result: {
+        ...rawPayload.result,
+        data: [[1200000, [30]]],
+      },
+    })
+    await fetch
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(mockChart.getPayload()).toBe(previousPayload)
+    expect(mockChart.getAttribute("liveAnchor")).toBe(1000000)
+    expect(mockChart.getAttribute("loading")).toBe(false)
+    expect(mockChart.trigger).not.toHaveBeenCalledWith(
+      "successFetch",
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it("accepts an in-flight response when the frozen window matches its request", async () => {
+    mockChart.updateAttributes({
+      firstEntry: 1,
+      loaded: true,
+      liveAnchor: 1000000,
+    })
+    let resolveFetch
+    mockChart.getChart.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveFetch = resolve
+        })
+    )
+    global.Date.now.mockReturnValue(1000500)
+
+    const fetch = mockChart.fetch()
+    mockChart.updateAttributes({
+      hovering: true,
+      renderedAt: 1001000,
+    })
+    resolveFetch(rawPayload)
+    await fetch
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(mockChart.getAttribute("liveAnchor")).toBe(1001000)
+    expect(mockChart.trigger).toHaveBeenCalledWith("successFetch", expect.anything(), null)
   })
 
   it("invalidates rendering only when a successful payload becomes current", async () => {

--- a/src/sdk/makeNode.js
+++ b/src/sdk/makeNode.js
@@ -179,7 +179,7 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
   onAttributeChange("timezone", tz => updateIntls(tz, getAttribute("locale")))
   onAttributeChange("locale", locale => updateIntls(getAttribute("timezone"), locale))
 
-  const pauseReasons = new Set()
+  const pauseReasons = new Map()
   const computeAggregatePaused = () => {
     const blurReason = !getAttribute("autofetchOnWindowBlur") && getAttribute("blurred")
     return Boolean(blurReason) || pauseReasons.size > 0
@@ -187,9 +187,9 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
   const applyAggregatePaused = () => {
     updateAttribute("paused", computeAggregatePaused())
   }
-  const addPauseReason = reasonId => {
+  const addPauseReason = (reasonId, reasonType = "interaction") => {
     if (!reasonId) return
-    pauseReasons.add(reasonId)
+    pauseReasons.set(reasonId, reasonType)
     applyAggregatePaused()
   }
   const removePauseReason = reasonId => {
@@ -197,6 +197,19 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
     if (!pauseReasons.delete(reasonId)) return
     applyAggregatePaused()
   }
+  const removePauseReasonsByType = reasonType => {
+    let removed = false
+    pauseReasons.forEach((type, reasonId) => {
+      if (type !== reasonType) return
+
+      pauseReasons.delete(reasonId)
+      removed = true
+    })
+    if (removed) applyAggregatePaused()
+  }
+  const getPauseReasons = () =>
+    Array.from(pauseReasons, ([reasonId, reasonType]) => ({ reasonId, reasonType }))
+  const reconcilePlaybackState = (options = {}) => sdk.trigger("reconcilePlaybackState", options)
   onAttributeChange("blurred", applyAggregatePaused)
   onAttributeChange("autofetchOnWindowBlur", applyAggregatePaused)
 
@@ -244,6 +257,9 @@ export default ({ sdk, parent = null, attributes: initialAttributes }) => {
     formatXAxis,
     addPauseReason,
     removePauseReason,
+    removePauseReasonsByType,
+    getPauseReasons,
+    reconcilePlaybackState,
   }
 
   return instance

--- a/src/sdk/makeNode.test.js
+++ b/src/sdk/makeNode.test.js
@@ -271,6 +271,42 @@ describe("makeNode", () => {
       expect(node.getAttribute("paused")).toBe(false)
     })
 
+    it("tracks reason types without exposing mutable internal state", () => {
+      node.addPauseReason("hover-1", "hover")
+      node.addPauseReason("modal-1")
+
+      const reasons = node.getPauseReasons()
+      expect(reasons).toEqual([
+        { reasonId: "hover-1", reasonType: "hover" },
+        { reasonId: "modal-1", reasonType: "interaction" },
+      ])
+
+      reasons.pop()
+      expect(node.getPauseReasons()).toHaveLength(2)
+    })
+
+    it("removes all reasons of one type and preserves the others", () => {
+      node.addPauseReason("hover-1", "hover")
+      node.addPauseReason("hover-2", "hover")
+      node.addPauseReason("modal-1")
+
+      node.removePauseReasonsByType("hover")
+
+      expect(node.getPauseReasons()).toEqual([{ reasonId: "modal-1", reasonType: "interaction" }])
+      expect(node.getAttribute("paused")).toBe(true)
+
+      node.removePauseReason("modal-1")
+      expect(node.getAttribute("paused")).toBe(false)
+    })
+
+    it("requests playback reconciliation through the SDK", () => {
+      node.reconcilePlaybackState({ clearHover: true })
+
+      expect(mockSdk.trigger).toHaveBeenCalledWith("reconcilePlaybackState", {
+        clearHover: true,
+      })
+    })
+
     it("ignores empty/missing reason ids", () => {
       node.addPauseReason("")
       node.addPauseReason(null)

--- a/src/sdk/plugins/hover.js
+++ b/src/sdk/plugins/hover.js
@@ -31,8 +31,6 @@ export default sdk => {
     })
     .on("blurChart", chart => {
       chart.getApplicableNodes({ syncHover: true }).forEach(node => {
-        if (chart.getRoot().getAttribute("paused")) return
-
         node.updateAttributes({ hovering: false, renderedAt: null })
       })
       sdk.trigger("play:blurChart", chart)

--- a/src/sdk/plugins/hover.js
+++ b/src/sdk/plugins/hover.js
@@ -31,7 +31,7 @@ export default sdk => {
     })
     .on("blurChart", chart => {
       chart.getApplicableNodes({ syncHover: true }).forEach(node => {
-        node.updateAttributes({ hovering: false, renderedAt: null })
+        node.updateAttributes({ hovering: false, hoverX: null, renderedAt: null })
       })
       sdk.trigger("play:blurChart", chart)
     })

--- a/src/sdk/plugins/play.js
+++ b/src/sdk/plugins/play.js
@@ -1,5 +1,8 @@
 export default sdk => {
   let timeoutId
+  let reconciliationRevision = 0
+  let reconcilingBrowserFocus = false
+  let registered = true
   const root = sdk.getRoot()
 
   const isRenderingPaused = chart => {
@@ -88,9 +91,38 @@ export default sdk => {
     if (previousPaused === root.getAttribute("paused")) refreshPlaybackState()
   }
 
-  const blur = () => reconcilePlaybackState({ blurred: true })
-  const focus = () => reconcilePlaybackState({ blurred: false })
-  const visibilityChange = () => reconcilePlaybackState()
+  const focus = () => {
+    if (document.visibilityState === "hidden") {
+      reconcilePlaybackState({ blurred: true })
+      return
+    }
+
+    const revision = ++reconciliationRevision
+    reconcilingBrowserFocus = true
+    root.updateAttribute("blurred", false)
+
+    queueMicrotask(() => {
+      if (!registered || revision !== reconciliationRevision) return
+
+      reconcilingBrowserFocus = false
+      reconcilePlaybackState()
+    })
+  }
+
+  const blur = () => {
+    reconciliationRevision += 1
+    reconcilingBrowserFocus = false
+    reconcilePlaybackState({ blurred: true })
+  }
+  const visibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      if (typeof document.hasFocus !== "function" || document.hasFocus()) focus()
+      else reconcilePlaybackState()
+      return
+    }
+
+    blur()
+  }
 
   window.addEventListener("blur", blur)
   window.addEventListener("focus", focus)
@@ -103,6 +135,8 @@ export default sdk => {
       autofetchIfActive(chart, { force: true })
     })
     .on("play:hoverChart", chart => {
+      if (reconcilingBrowserFocus) return
+
       toggleRender(sdk.getRoot().getAttribute("autofetchOnHovering"))
 
       if (sdk.getRoot().getAttribute("paused")) return
@@ -112,6 +146,7 @@ export default sdk => {
         .forEach(node => autofetchIfActive(node, { now: chart.getAttribute("renderedAt") }))
     })
     .on("play:blurChart", chart => {
+      if (reconcilingBrowserFocus) return
       if (chart.getRoot().getAttribute("paused")) return
 
       toggleRender(chart.getAttribute("after") < 0 && !isRenderingPaused(chart))
@@ -128,10 +163,15 @@ export default sdk => {
     })
     .on("reconcilePlaybackState", reconcilePlaybackState)
 
-  const offPaused = root.onAttributeChange("paused", refreshPlaybackState)
+  const offPaused = root.onAttributeChange("paused", () => {
+    if (!reconcilingBrowserFocus) refreshPlaybackState()
+  })
   root.updateAttribute("blurred", document.visibilityState === "hidden")
 
   return () => {
+    registered = false
+    reconciliationRevision += 1
+    reconcilingBrowserFocus = false
     offs()
     offPaused()
     clearTimeout(timeoutId)

--- a/src/sdk/plugins/play.js
+++ b/src/sdk/plugins/play.js
@@ -1,8 +1,8 @@
 export default sdk => {
   let timeoutId
+  const root = sdk.getRoot()
 
   const isRenderingPaused = chart => {
-    const root = sdk.getRoot()
     return (
       (!root.getAttribute("autofetchOnHovering") && chart?.getAttribute("hovering")) ||
       (!root.getAttribute("autofetchOnWindowBlur") && root.getAttribute("blurred")) ||
@@ -11,13 +11,13 @@ export default sdk => {
   }
 
   const getNext = () => {
-    if (!sdk.getRoot().getAttribute("paused") && sdk.getRoot().getAttribute("after") < 0)
-      sdk.getRoot().setAttribute("fetchAt", Date.now())
+    if (!root.getAttribute("paused") && root.getAttribute("after") < 0)
+      root.setAttribute("fetchAt", Date.now())
 
     sdk
       .getNodes(
         (node, { loaded, active }) =>
-          node.type === "chart" && loaded && active && !sdk.getRoot().getAttribute("paused")
+          node.type === "chart" && loaded && active && !root.getAttribute("paused")
       )
       .forEach(node => node.trigger("render"))
 
@@ -56,24 +56,45 @@ export default sdk => {
     }
   }
 
-  const blur = () => {
-    sdk.getRoot().updateAttributes({
-      blurred: true,
+  const refreshPlaybackState = () => {
+    toggleRender(root.getAttribute("after") < 0 && !isRenderingPaused())
+    sdk.getNodes().forEach(node => autofetchIfActive(node))
+  }
+
+  const isDocumentBlurred = () =>
+    document.visibilityState === "hidden" ||
+    (typeof document.hasFocus === "function" && !document.hasFocus())
+
+  const clearHoverState = () => {
+    sdk.getNodes().forEach(node => {
+      const attributes = {}
+      if (node.getAttribute("focused")) attributes.focused = false
+      if (node.getAttribute("hovering")) attributes.hovering = false
+      if (node.getAttribute("renderedAt") !== null) attributes.renderedAt = null
+      if (Object.keys(attributes).length) node.updateAttributes(attributes)
     })
-    toggleRender(sdk.getRoot().getAttribute("after") < 0 && !isRenderingPaused())
 
-    sdk.getNodes().forEach(node => autofetchIfActive(node))
+    root.removePauseReasonsByType("hover")
   }
 
-  const focus = () => {
-    sdk.getRoot().updateAttributes({ blurred: false })
-    toggleRender(sdk.getRoot().getAttribute("after") < 0 && !isRenderingPaused())
+  const reconcilePlaybackState = (options = {}) => {
+    const { blurred = isDocumentBlurred(), clearHover = false } =
+      typeof options === "object" && options ? options : {}
+    const previousPaused = root.getAttribute("paused")
 
-    sdk.getNodes().forEach(node => autofetchIfActive(node))
+    if (clearHover) clearHoverState()
+    root.updateAttribute("blurred", blurred)
+
+    if (previousPaused === root.getAttribute("paused")) refreshPlaybackState()
   }
+
+  const blur = () => reconcilePlaybackState({ blurred: true })
+  const focus = () => reconcilePlaybackState({ blurred: false })
+  const visibilityChange = () => reconcilePlaybackState()
 
   window.addEventListener("blur", blur)
   window.addEventListener("focus", focus)
+  document.addEventListener("visibilitychange", visibilityChange)
 
   const offs = sdk
     .on("active", chart => {
@@ -105,14 +126,17 @@ export default sdk => {
         autofetchIfActive(node)
       })
     })
+    .on("reconcilePlaybackState", reconcilePlaybackState)
 
-  sdk
-    .getRoot()
-    .onAttributeChange("paused", () => sdk.getNodes().forEach(node => autofetchIfActive(node)))
+  const offPaused = root.onAttributeChange("paused", refreshPlaybackState)
+  root.updateAttribute("blurred", document.visibilityState === "hidden")
 
   return () => {
     offs()
+    offPaused()
+    clearTimeout(timeoutId)
     window.removeEventListener("blur", blur)
     window.removeEventListener("focus", focus)
+    document.removeEventListener("visibilitychange", visibilityChange)
   }
 }

--- a/src/sdk/plugins/play.js
+++ b/src/sdk/plugins/play.js
@@ -73,6 +73,7 @@ export default sdk => {
       const attributes = {}
       if (node.getAttribute("focused")) attributes.focused = false
       if (node.getAttribute("hovering")) attributes.hovering = false
+      if (node.getAttribute("hoverX") !== null) attributes.hoverX = null
       if (node.getAttribute("renderedAt") !== null) attributes.renderedAt = null
       if (Object.keys(attributes).length) node.updateAttributes(attributes)
     })

--- a/src/sdk/plugins/play.test.js
+++ b/src/sdk/plugins/play.test.js
@@ -31,10 +31,12 @@ const makePlaybackSDK = () => {
 describe("play plugin", () => {
   let chart
   let sdk
+  let hasFocus
   let visibilityDescriptor
 
   beforeEach(() => {
     jest.useFakeTimers()
+    hasFocus = jest.spyOn(document, "hasFocus").mockReturnValue(true)
     visibilityDescriptor = Object.getOwnPropertyDescriptor(document, "visibilityState")
     setVisibility("visible")
 
@@ -51,6 +53,7 @@ describe("play plugin", () => {
 
     jest.clearAllTimers()
     jest.useRealTimers()
+    hasFocus.mockRestore()
     document.body.innerHTML = ""
 
     if (visibilityDescriptor)
@@ -74,8 +77,34 @@ describe("play plugin", () => {
     expect(root.getAttribute("hovering")).toBe(false)
 
     window.dispatchEvent(new Event("focus"))
+    jest.runAllTicks()
+
     expect(root.getAttribute("paused")).toBe(false)
     expect(root.getAttribute("autofetch")).toBe(true)
+  })
+
+  it("reconciles chart hover before resuming playback on focus", () => {
+    const playback = makePlaybackSDK()
+    chart = playback.chart
+    sdk = playback.sdk
+    const root = sdk.getRoot()
+    const reconcileHover = () => chart.focus()
+
+    window.addEventListener("focus", reconcileHover)
+    window.dispatchEvent(new Event("blur"))
+    window.dispatchEvent(new Event("focus"))
+
+    expect(root.getAttribute("blurred")).toBe(false)
+    expect(root.getAttribute("hovering")).toBe(true)
+    expect(root.getAttribute("autofetch")).toBe(false)
+
+    jest.runAllTicks()
+
+    expect(root.getAttribute("blurred")).toBe(false)
+    expect(root.getAttribute("hovering")).toBe(true)
+    expect(root.getAttribute("autofetch")).toBe(false)
+
+    window.removeEventListener("focus", reconcileHover)
   })
 
   it("manual reconciliation clears hover blockers but preserves other reasons", () => {
@@ -113,6 +142,7 @@ describe("play plugin", () => {
     setVisibility("visible")
     document.querySelector("button").focus()
     document.dispatchEvent(new Event("visibilitychange"))
+    jest.runAllTicks()
 
     expect(root.getAttribute("blurred")).toBe(false)
     expect(root.getAttribute("paused")).toBe(false)
@@ -133,6 +163,9 @@ describe("play plugin", () => {
 
     root.updateAttribute("blurred", false)
     window.dispatchEvent(new Event("blur"))
+    expect(root.getAttribute("blurred")).toBe(false)
+    window.dispatchEvent(new Event("focus"))
+    jest.runAllTicks()
     expect(root.getAttribute("blurred")).toBe(false)
 
     sdk.unregister("hover")

--- a/src/sdk/plugins/play.test.js
+++ b/src/sdk/plugins/play.test.js
@@ -1,0 +1,141 @@
+import makeSDK from "@/sdk"
+import hover from "./hover"
+import play from "./play"
+
+const setVisibility = visibilityState => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: visibilityState,
+  })
+}
+
+const makePlaybackSDK = () => {
+  const sdk = makeSDK({
+    ui: {},
+    plugins: { hover, play },
+    attributes: {
+      after: -900,
+      autofetchOnWindowBlur: false,
+    },
+  })
+  const chart = sdk.makeChartCore()
+  chart.setUI({
+    getRenderedAt: () => Date.now(),
+    unmount: () => {},
+  })
+  sdk.appendChild(chart)
+
+  return { chart, sdk }
+}
+
+describe("play plugin", () => {
+  let chart
+  let sdk
+  let visibilityDescriptor
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    visibilityDescriptor = Object.getOwnPropertyDescriptor(document, "visibilityState")
+    setVisibility("visible")
+
+    const focusTarget = document.createElement("button")
+    document.body.appendChild(focusTarget)
+    focusTarget.focus()
+  })
+
+  afterEach(() => {
+    if (sdk) {
+      sdk.unregister("play")
+      sdk.unregister("hover")
+    }
+
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    document.body.innerHTML = ""
+
+    if (visibilityDescriptor)
+      Object.defineProperty(document, "visibilityState", visibilityDescriptor)
+    else delete document.visibilityState
+  })
+
+  it("recovers after chart hover ends while the window is blurred", () => {
+    const playback = makePlaybackSDK()
+    chart = playback.chart
+    sdk = playback.sdk
+    const root = sdk.getRoot()
+
+    chart.focus()
+    expect(root.getAttribute("hovering")).toBe(true)
+
+    window.dispatchEvent(new Event("blur"))
+    expect(root.getAttribute("paused")).toBe(true)
+
+    chart.blur()
+    expect(root.getAttribute("hovering")).toBe(false)
+
+    window.dispatchEvent(new Event("focus"))
+    expect(root.getAttribute("paused")).toBe(false)
+    expect(root.getAttribute("autofetch")).toBe(true)
+  })
+
+  it("manual reconciliation clears hover blockers but preserves other reasons", () => {
+    const playback = makePlaybackSDK()
+    chart = playback.chart
+    sdk = playback.sdk
+    const root = sdk.getRoot()
+
+    chart.focus()
+    root.addPauseReason("hover-1", "hover")
+    root.addPauseReason("modal-1")
+
+    root.reconcilePlaybackState({ clearHover: true, blurred: false })
+
+    expect(chart.getAttribute("focused")).toBe(false)
+    expect(root.getAttribute("hovering")).toBe(false)
+    expect(root.getPauseReasons()).toEqual([{ reasonId: "modal-1", reasonType: "interaction" }])
+    expect(root.getAttribute("paused")).toBe(true)
+
+    root.removePauseReason("modal-1")
+    expect(root.getAttribute("paused")).toBe(false)
+    expect(root.getAttribute("autofetch")).toBe(true)
+  })
+
+  it("initializes from visibility and resumes when the visible document is focused", () => {
+    setVisibility("hidden")
+    const playback = makePlaybackSDK()
+    chart = playback.chart
+    sdk = playback.sdk
+    const root = sdk.getRoot()
+
+    expect(root.getAttribute("blurred")).toBe(true)
+    expect(root.getAttribute("paused")).toBe(true)
+
+    setVisibility("visible")
+    document.querySelector("button").focus()
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    expect(root.getAttribute("blurred")).toBe(false)
+    expect(root.getAttribute("paused")).toBe(false)
+    expect(root.getAttribute("autofetch")).toBe(true)
+  })
+
+  it("removes browser listeners and its render timer when unregistered", () => {
+    const playback = makePlaybackSDK()
+    chart = playback.chart
+    sdk = playback.sdk
+    const root = sdk.getRoot()
+
+    root.reconcilePlaybackState({ blurred: false })
+    expect(jest.getTimerCount()).toBeGreaterThan(0)
+
+    sdk.unregister("play")
+    expect(jest.getTimerCount()).toBe(0)
+
+    root.updateAttribute("blurred", false)
+    window.dispatchEvent(new Event("blur"))
+    expect(root.getAttribute("blurred")).toBe(false)
+
+    sdk.unregister("hover")
+    sdk = null
+  })
+})

--- a/src/sdk/plugins/play.test.js
+++ b/src/sdk/plugins/play.test.js
@@ -68,13 +68,17 @@ describe("play plugin", () => {
     const root = sdk.getRoot()
 
     chart.focus()
+    sdk.trigger("highlightHover", chart, 1000, "dimension")
     expect(root.getAttribute("hovering")).toBe(true)
+    expect(root.getAttribute("hoverX")).toEqual([1000, "dimension"])
 
     window.dispatchEvent(new Event("blur"))
     expect(root.getAttribute("paused")).toBe(true)
 
     chart.blur()
     expect(root.getAttribute("hovering")).toBe(false)
+    expect(root.getAttribute("hoverX")).toBeNull()
+    expect(chart.getAttribute("hoverX")).toBeNull()
 
     window.dispatchEvent(new Event("focus"))
     jest.runAllTicks()
@@ -114,13 +118,16 @@ describe("play plugin", () => {
     const root = sdk.getRoot()
 
     chart.focus()
+    sdk.trigger("highlightHover", chart, 1000, "dimension")
     root.addPauseReason("hover-1", "hover")
     root.addPauseReason("modal-1")
 
     root.reconcilePlaybackState({ clearHover: true, blurred: false })
 
     expect(chart.getAttribute("focused")).toBe(false)
+    expect(chart.getAttribute("hoverX")).toBeNull()
     expect(root.getAttribute("hovering")).toBe(false)
+    expect(root.getAttribute("hoverX")).toBeNull()
     expect(root.getPauseReasons()).toEqual([{ reasonId: "modal-1", reasonType: "interaction" }])
     expect(root.getAttribute("paused")).toBe(true)
 


### PR DESCRIPTION
## Summary

- Recover chart playback from current window visibility, focus, and DOM hover state.
- Defer focus-triggered refresh until hover state has been reconciled.
- Keep paused or hovered chart requests on the visible time window and reject in-flight responses for a different live window.
- Release focused charts during deactivate/destroy and clean up playback timers and browser listeners.
- Clear stale historical legend positions whenever chart hover or playback reconciliation ends.

## Root cause

When a window lost focus while a chart was hovered, the browser could omit the expected mouseout transition. Hover cleanup also returned early while playback was paused, leaving stale `focused`, `hovering`, and `renderedAt` state that continued blocking playback.

The highlighted timestamp had a second, independent lifecycle. Outer chart blur cleared `hovering`, while only the Dygraph-specific mouseout cleared `hoverX`. If that event was omitted, playback and sorting resumed from current data while legend values remained pinned to the old timestamp.

Focus recovery could also start a current-time request before the chart's DOM hover state was restored. If hover then froze the older rendered window while that request was in flight, its response replaced the old-window payload without moving the frozen viewport, producing a gap on the left.

## Impact

Playback now recovers after focus and visibility transitions without refreshing against an intermediate hover state. A chart frozen by hover or pause keeps data and viewport on the same time window, including for long view-update windows.

Legend values now return to the latest payload when hover ends, even if the Dygraph mouseout event is lost. Value sorting and displayed values therefore remain aligned during automatic refreshes.

Existing one-argument `addPauseReason(id)` callers remain compatible and default to an interaction pause.

## Follow-up

Consumed by netdata/cloud-frontend#5642 after this change is released.

## Validation

- Full test suite: 147 suites passed; 1,405 tests passed; 2 skipped.
- Regression test verifies a legend pinned at historical value `50` returns to current value `60` after outer chart blur without a Dygraph mouseout.
- Production CommonJS and ES module builds passed.
- Changed-file ESLint and diff checks passed.
