### PR TITLE
Skip hidden Dygraph series extraction

### DIFF
--- a/src/chartLibraries/dygraph/reusableLineDataHandler.js
+++ b/src/chartLibraries/dygraph/reusableLineDataHandler.js
@@ -93,9 +93,15 @@ export const makeReusableLineDataHandler = () => {
         reset(nextLabels, rawData.length)
       }
 
+      const seriesLabel = nextLabels[seriesIndex]
+      if (options.get("visibility")?.[seriesIndex - 1] === false) {
+        if (seriesByIndex[seriesIndex]) seriesByIndex[seriesIndex] = null
+        pointsByName.delete(seriesLabel)
+        return []
+      }
+
       if (!reusable) return super.extractSeries(rawData, seriesIndex, options)
 
-      const seriesLabel = nextLabels[seriesIndex]
       const logScale = options.getForSeries("logscale", seriesLabel)
       let series = seriesByIndex[seriesIndex]
 

--- a/src/chartLibraries/dygraph/reusableLineDataHandler.test.js
+++ b/src/chartLibraries/dygraph/reusableLineDataHandler.test.js
@@ -180,6 +180,68 @@ describe("reusable line data handler", () => {
     expect(dygraph.layout_.points[0][0].name).toBe("second")
   })
 
+  it("skips hidden series and rebuilds them when they become visible", () => {
+    const labels = ["time", "first", "second"]
+    const data = [
+      [1000, -1, 2],
+      [2000, 3, 4],
+      [3000, 5, 8],
+      [4000, 7, null],
+    ]
+    const options = {
+      labels,
+      dateWindow: [1500, 3500],
+      logscale: true,
+      rollPeriod: 2,
+    }
+    const reference = makeDygraph(data, options)
+    const candidate = makeDygraph(data, {
+      ...options,
+      dataHandler: makeReusableLineDataHandler(),
+    })
+    const secondSeries = candidate.rolledSeries_[2]
+    const secondPoint = candidate.layout_.points[1][0]
+    const annotations = [{ series: "second", x: 2000, shortText: "A" }]
+
+    reference.setAnnotations(annotations)
+    candidate.setAnnotations(annotations)
+
+    reference.updateOptions({ visibility: [true, false] })
+    candidate.updateOptions({ visibility: [true, false] })
+
+    expect(candidate.rolledSeries_[2]).toEqual([])
+    expect(candidate.layout_.setNames).toEqual(reference.layout_.setNames)
+    const hiddenReference = snapshot(reference)
+    const hiddenCandidate = snapshot(candidate)
+    expect({
+      points: hiddenCandidate.points,
+      xRange: hiddenCandidate.xRange,
+      yRange: hiddenCandidate.yRange,
+    }).toEqual({
+      points: hiddenReference.points,
+      xRange: hiddenReference.xRange,
+      yRange: hiddenReference.yRange,
+    })
+
+    const nextData = [
+      [2000, 9, 16],
+      [3000, 11, 32],
+      [4000, 13, 64],
+      [5000, 15, 128],
+    ]
+    reference.updateOptions({ file: nextData })
+    candidate.updateOptions({ file: nextData })
+    reference.updateOptions({ visibility: [true, true] })
+    candidate.updateOptions({ visibility: [true, true] })
+
+    expect(candidate.rolledSeries_[2]).not.toBe(secondSeries)
+    expect(candidate.layout_.points[1][0]).not.toBe(secondPoint)
+    expect(snapshot(candidate)).toEqual(snapshot(reference))
+    expect(candidate.layout_.points[1].map(point => point.annotation?.shortText)).toEqual(
+      reference.layout_.points[1].map(point => point.annotation?.shortText)
+    )
+  })
+
   it("does not retain removed annotations on reused points", () => {
     const labels = ["time", "value"]
     const dygraph = makeDygraph([[1000, 1]], {


### PR DESCRIPTION
## What

- Skip Dygraph series extraction when a series is explicitly hidden.
- Release cached series and point structures while hidden.
- Rebuild those structures when the series becomes visible again.

## Why

Dygraph asks the data handler to extract every returned series before its later visibility checks. With high-cardinality responses and a small selected subset, this performs point transformation and allocation for thousands of series that cannot be drawn.

## Impact

- No payload, chart output, selection, or refresh-policy change.
- Work is reduced in proportion to the number of hidden series.
- Fully visible charts follow the existing path unchanged.

## Measurement

Alternating same-page A/B runs with 6,000 returned dimensions, 20 visible dimensions, and 297 points:

| | Baseline | Optimized |
|---|---:|---:|
| Median accepted-response-to-render | 125.7 ms | 111.8 ms |
| Mean accepted-response-to-render | 138.0 ms | 110.4 ms |

This is an 11% median reduction and a 20% mean reduction for the measured workload.

## Checks

- Focused regression test with real Dygraph, including visibility changes, data updates, zoom, rolling, logarithmic scale, and annotations
- Focused ESLint check
- Full Jest suite: 146/146 suites; 1,388 passed, 2 skipped
- Production build: 471 CommonJS and 471 ES module files