### PR TITLE
Reduce smooth line plotter allocations

### DIFF
--- a/src/chartLibraries/dygraph/plotters/linePlotter.js
+++ b/src/chartLibraries/dygraph/plotters/linePlotter.js
@@ -1,5 +1,88 @@
+import Dygraph from "dygraphs/src/dygraph"
 import "dygraphs/src/extras/smooth-plotter"
 
-export default () => plotter => {
-  window.smoothPlotter(plotter)
+const isValidPoint = point => point && point.canvasy && !isNaN(point.canvasy)
+
+const smoothLinePlotter = ({ drawingContext, points }) => {
+  drawingContext.beginPath()
+  drawingContext.moveTo(points[0].canvasx, points[0].canvasy)
+
+  let lastRightX = points[0].canvasx
+  let lastRightY = points[0].canvasy
+  const configuredSmoothing = Dygraph.smoothPlotter.smoothing
+  const alpha = configuredSmoothing === undefined ? 1 / 3 : configuredSmoothing
+
+  for (let index = 1; index < points.length; index++) {
+    const previous = isValidPoint(points[index - 1]) ? points[index - 1] : null
+    const point = isValidPoint(points[index]) ? points[index] : null
+    const next = isValidPoint(points[index + 1]) ? points[index + 1] : null
+
+    if (previous && point) {
+      let leftX
+      let leftY
+      let rightX
+      let rightY
+
+      if (!next) {
+        leftX = point.canvasx
+        leftY = point.canvasy
+        rightX = null
+        rightY = null
+      } else {
+        leftX = (1 - alpha) * point.canvasx + alpha * previous.canvasx
+        leftY = (1 - alpha) * point.canvasy + alpha * previous.canvasy
+        rightX = (1 - alpha) * point.canvasx + alpha * next.canvasx
+        rightY = (1 - alpha) * point.canvasy + alpha * next.canvasy
+
+        if (leftX != rightX) {
+          const deltaY =
+            point.canvasy -
+            rightY -
+            ((point.canvasx - rightX) * (leftY - rightY)) / (leftX - rightX)
+          leftY += deltaY
+          rightY += deltaY
+        }
+
+        if (leftY > previous.canvasy && leftY > point.canvasy) {
+          leftY = Math.max(previous.canvasy, point.canvasy)
+          rightY = 2 * point.canvasy - leftY
+        } else if (leftY < previous.canvasy && leftY < point.canvasy) {
+          leftY = Math.min(previous.canvasy, point.canvasy)
+          rightY = 2 * point.canvasy - leftY
+        }
+
+        if (rightY > point.canvasy && rightY > next.canvasy) {
+          rightY = Math.max(point.canvasy, next.canvasy)
+          leftY = 2 * point.canvasy - rightY
+        } else if (rightY < point.canvasy && rightY < next.canvasy) {
+          rightY = Math.min(point.canvasy, next.canvasy)
+          leftY = 2 * point.canvasy - rightY
+        }
+      }
+
+      lastRightX = lastRightX !== null ? lastRightX : previous.canvasx
+      lastRightY = lastRightY !== null ? lastRightY : previous.canvasy
+      drawingContext.bezierCurveTo(
+        lastRightX,
+        lastRightY,
+        leftX,
+        leftY,
+        point.canvasx,
+        point.canvasy
+      )
+      lastRightX = rightX
+      lastRightY = rightY
+    } else if (point) {
+      drawingContext.moveTo(point.canvasx, point.canvasy)
+      lastRightX = point.canvasx
+      lastRightY = point.canvasy
+    } else {
+      lastRightX = null
+      lastRightY = null
+    }
+  }
+
+  drawingContext.stroke()
 }
+
+export default () => smoothLinePlotter

--- a/src/chartLibraries/dygraph/plotters/linePlotter.test.js
+++ b/src/chartLibraries/dygraph/plotters/linePlotter.test.js
@@ -1,8 +1,81 @@
+import Dygraph from "dygraphs/src/dygraph"
 import linePlotter from "./linePlotter"
+
+const makeContext = () => {
+  const calls = []
+  const drawingContext = {}
+
+  ;["beginPath", "moveTo", "bezierCurveTo", "stroke"].forEach(method => {
+    drawingContext[method] = (...args) => calls.push([method, ...args])
+  })
+
+  return { calls, drawingContext }
+}
+
+const expectSameDrawing = (points, smoothing) => {
+  const previousSmoothing = Dygraph.smoothPlotter.smoothing
+  const reference = makeContext()
+  const candidate = makeContext()
+
+  try {
+    Dygraph.smoothPlotter.smoothing = smoothing
+    Dygraph.smoothPlotter({ drawingContext: reference.drawingContext, points })
+    linePlotter()({ drawingContext: candidate.drawingContext, points })
+  } finally {
+    Dygraph.smoothPlotter.smoothing = previousSmoothing
+  }
+
+  expect(candidate.calls).toEqual(reference.calls)
+}
 
 describe("linePlotter", () => {
   it("returns a function", () => {
     const plotter = linePlotter()
     expect(typeof plotter).toBe("function")
   })
+
+  it.each([
+    {
+      name: "continuous points",
+      points: [
+        { canvasx: 10, canvasy: 40 },
+        { canvasx: 20, canvasy: 10 },
+        { canvasx: 30, canvasy: 60 },
+        { canvasx: 40, canvasy: 20 },
+      ],
+    },
+    {
+      name: "missing and zero-height points",
+      points: [
+        { canvasx: 10, canvasy: 40 },
+        { canvasx: 20, canvasy: null },
+        { canvasx: 30, canvasy: 20 },
+        { canvasx: 40, canvasy: 0 },
+        { canvasx: 50, canvasy: 30 },
+        { canvasx: 60, canvasy: NaN },
+      ],
+    },
+    {
+      name: "two points",
+      points: [
+        { canvasx: 10, canvasy: 40 },
+        { canvasx: 20, canvasy: 10 },
+      ],
+    },
+  ])("matches the Dygraph smooth plotter for $name", ({ points }) => {
+    expectSameDrawing(points, Dygraph.smoothPlotter.smoothing)
+  })
+
+  it.each([undefined, 0, 0.2, 1 / 3, 0.8])(
+    "matches the Dygraph smooth plotter with smoothing %s",
+    smoothing => {
+      const values = [10, 90, -20, 60, 5, 120, 0, null, 40, NaN, 80, 15, Infinity, 30]
+      const points = Array.from({ length: 140 }, (_, index) => ({
+        canvasx: index % 17 === 0 ? index - 1 : index,
+        canvasy: values[index % values.length],
+      }))
+
+      expectSameDrawing(points, smoothing)
+    }
+  )
 })


### PR DESCRIPTION
## What changed

- Replace the wrapper around Dygraph's smooth-line plotter with an equivalent custom plotter that keeps control-point coordinates in scalar locals.
- Preserve Dygraph's smoothing setting through the same module instance used by the smooth-plotter extension.
- Add differential tests that compare the complete ordered Canvas call sequence against the installed Dygraph implementation for continuous data, gaps, zero/invalid points, duplicate X positions, and custom/default smoothing values.

This does not change payloads, refresh policy, interpolation, chart data, or visible output.

## Why

Dygraph's smooth plotter creates two or three temporary point objects plus a four-value control array for every rendered line segment. A chart with 6,000 visible dimensions and 297 points therefore creates roughly seven million short-lived objects during one render, adding garbage-collection pressure on the main thread.

## Measurements

Measured in the same high-cardinality Storybook scenario with 6,000 visible dimensions and 297 points:

| Implementation | Samples | Median | Mean | p95 / worst |
| --- | ---: | ---: | ---: | ---: |
| Current | 10 | 456.4 ms | 455.7 ms | 533.4 ms |
| Candidate | 20 | 413.6 ms | 420.7 ms | 513.3 ms |

The candidate reduced median update time by about 9.4% and mean time by about 7.7%.

Sampled post-update heap high-water marks were approximately 1.68 GiB for the current implementation and 0.86 GiB for the candidate. These are post-update browser heap samples, not precise allocation peaks, so they indicate reduced retained/queued pressure rather than an exact allocation reduction.

## Validation

- `yarn test --runInBand`: 146/146 suites passed; 1,395 tests passed and 2 skipped.
- Focused differential test: 9/9 passed with 100% statement/function/line coverage and 95.12% branch coverage for the plotter.
- ESLint passes for both changed files.
- `yarn build`: CommonJS and ES6 builds passed, 471 files each.
- Repository-wide lint still reports 36 existing errors in unrelated files; this PR introduces none of them.
