### PR TITLE
Reduce chart hover layout and sorting work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/charts",
-  "version": "6.12.9",
+  "version": "6.12.10",
   "description": "Netdata frontend SDK and chart utilities",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",

--- a/src/components/helpers/fontSizer.js
+++ b/src/components/helpers/fontSizer.js
@@ -1,5 +1,26 @@
 import React, { useState, useEffect, useRef } from "react"
 
+export const findFittedFontSize = ({ minFontSize, maxFontSize, fits }) => {
+  if (maxFontSize <= minFontSize || fits(maxFontSize)) return maxFontSize
+
+  let lower = minFontSize + 1
+  let upper = maxFontSize - 1
+  let fitted = minFontSize
+
+  while (lower <= upper) {
+    const fontSize = Math.floor((lower + upper) / 2)
+
+    if (fits(fontSize)) {
+      fitted = fontSize
+      lower = fontSize + 1
+    } else {
+      upper = fontSize - 1
+    }
+  }
+
+  return fitted
+}
+
 const FontSizer = ({
   children,
   Component = "div",
@@ -7,7 +28,6 @@ const FontSizer = ({
   maxWidth = 100,
   maxFontSize = 50,
   minFontSize = 10,
-  cacheKey,
   ...rest
 }) => {
   const [ref, setRef] = useState()
@@ -18,27 +38,29 @@ const FontSizer = ({
 
     const timeoutId = setTimeout(() => {
       cancelRef.current = false
-      let fontSize = maxFontSize
 
       ref.style.animation = "font-size 02s"
-      ref.style.fontSize = fontSize + "px"
+      const fontSize = findFittedFontSize({
+        minFontSize,
+        maxFontSize,
+        fits: nextFontSize => {
+          if (cancelRef.current) return true
 
-      while (
-        !cancelRef.current &&
-        fontSize > minFontSize &&
-        (ref.offsetWidth > maxWidth || ref.offsetHeight > maxHeight)
-      ) {
-        const delta = Math.ceil(fontSize / 100)
-        fontSize = fontSize - delta
-        ref.style.fontSize = fontSize + "px"
-      }
+          ref.style.fontSize = nextFontSize + "px"
+          return ref.offsetWidth <= maxWidth && ref.offsetHeight <= maxHeight
+        },
+      })
+
+      const fittedFontSize = fontSize + "px"
+      if (!cancelRef.current && ref.style.fontSize !== fittedFontSize)
+        ref.style.fontSize = fittedFontSize
     })
 
     return () => {
       cancelRef.current = true
       clearTimeout(timeoutId)
     }
-  }, [children, maxHeight, maxWidth, ref])
+  }, [children, maxFontSize, maxHeight, maxWidth, minFontSize, ref])
 
   return (
     <Component truncate ref={setRef} {...rest}>

--- a/src/components/helpers/fontSizer.test.js
+++ b/src/components/helpers/fontSizer.test.js
@@ -1,0 +1,77 @@
+import React from "react"
+import { act, render } from "@testing-library/react"
+import FontSizer, { findFittedFontSize } from "./fontSizer"
+
+const TestText = React.forwardRef(({ truncate, ...rest }, ref) => (
+  <div data-truncate={truncate} ref={ref} {...rest} />
+))
+
+describe("findFittedFontSize", () => {
+  it("finds every fitting threshold with at most seven probes", () => {
+    for (let threshold = 10; threshold <= 50; threshold += 1) {
+      let probes = 0
+      const fontSize = findFittedFontSize({
+        minFontSize: 10,
+        maxFontSize: 50,
+        fits: candidate => {
+          probes += 1
+          return candidate <= threshold
+        },
+      })
+
+      expect(fontSize).toBe(threshold)
+      expect(probes).toBeLessThanOrEqual(7)
+    }
+  })
+
+  it("keeps the minimum size when no candidate fits", () => {
+    const fontSize = findFittedFontSize({
+      minFontSize: 10,
+      maxFontSize: 50,
+      fits: () => false,
+    })
+
+    expect(fontSize).toBe(10)
+  })
+})
+
+describe("FontSizer", () => {
+  beforeEach(() => jest.useFakeTimers())
+
+  afterEach(() => jest.useRealTimers())
+
+  it("applies the largest fitting font size", () => {
+    const { getByText } = render(
+      <FontSizer
+        Component={TestText}
+        maxFontSize={50}
+        minFontSize={10}
+        maxWidth={235}
+        maxHeight={100}
+      >
+        value
+      </FontSizer>
+    )
+    const element = getByText("value")
+    let widthReads = 0
+
+    Object.defineProperties(element, {
+      offsetHeight: {
+        configurable: true,
+        get: () => Number.parseFloat(element.style.fontSize),
+      },
+      offsetWidth: {
+        configurable: true,
+        get: () => {
+          widthReads += 1
+          return Number.parseFloat(element.style.fontSize) * 10
+        },
+      },
+    })
+
+    act(() => jest.runOnlyPendingTimers())
+
+    expect(element.style.fontSize).toBe("23px")
+    expect(widthReads).toBeLessThanOrEqual(7)
+  })
+})

--- a/src/components/helpers/fontSizer.test.js
+++ b/src/components/helpers/fontSizer.test.js
@@ -2,9 +2,9 @@ import React from "react"
 import { act, render } from "@testing-library/react"
 import FontSizer, { findFittedFontSize } from "./fontSizer"
 
-const TestText = React.forwardRef(({ truncate, ...rest }, ref) => (
+const TestText = ({ truncate, ref, ...rest }) => (
   <div data-truncate={truncate} ref={ref} {...rest} />
-))
+)
 
 describe("findFittedFontSize", () => {
   it("finds every fitting threshold with at most seven probes", () => {

--- a/src/components/line/overlays/latestValue.js
+++ b/src/components/line/overlays/latestValue.js
@@ -65,7 +65,6 @@ const LatestValue = ({ dimensionId, textProps, ...rest }) => {
         {...defaultTextProps}
         color="textLite"
         {...textProps}
-        cacheKey={value}
       >
         {unit}
       </FontSizer>

--- a/src/components/line/popover/index.js
+++ b/src/components/line/popover/index.js
@@ -1,8 +1,6 @@
-import React, { useEffect, useLayoutEffect, useState, useRef, Fragment } from "react"
-import { Flex } from "@netdata/netdata-ui"
+import React, { useEffect, useLayoutEffect, useState, useRef } from "react"
 import ReactDOM from "react-dom"
 import DropContainer from "@netdata/netdata-ui/dist/components/drops/drop/container"
-import useMakeUpdatePosition from "@netdata/netdata-ui/dist/components/drops/drop/useMakeUpdatePosition"
 import useDropElement from "@netdata/netdata-ui/dist/hooks/useDropElement"
 import { unregister } from "@/helpers/makeListeners"
 import { useChart } from "@/components/provider"
@@ -12,7 +10,6 @@ const leftTopAlign = { right: "left", bottom: "top" }
 const leftBottomAlign = { right: "left", top: "bottom" }
 const rightTopAlign = { left: "right", bottom: "top" }
 const rightBottomAlign = { left: "right", top: "bottom" }
-const canHideTarget = false
 
 const getAlign = (left, top) => {
   if (left && top) return leftTopAlign
@@ -21,27 +18,122 @@ const getAlign = (left, top) => {
   return rightBottomAlign
 }
 
+const clamp = (value, max) => Math.min(Math.max(0, max), Math.max(0, value))
+
+export const getPopoverPosition = ({
+  height,
+  pointerX,
+  pointerY,
+  viewportHeight,
+  viewportWidth,
+  width,
+}) => {
+  const left = pointerX + width > viewportWidth
+  const top = pointerY + height > viewportHeight
+
+  return {
+    align: getAlign(left, top),
+    x: clamp(left ? pointerX - width : pointerX, viewportWidth - width),
+    y: clamp(top ? pointerY - height : pointerY, viewportHeight - height),
+  }
+}
+
+const getPointerPosition = event => ({
+  x: Number.isFinite(event.clientX)
+    ? event.clientX
+    : Number.isFinite(event.pageX)
+      ? event.pageX - window.scrollX
+      : (event.offsetX ?? event.layerX ?? 0),
+  y: Number.isFinite(event.clientY)
+    ? event.clientY
+    : Number.isFinite(event.pageY)
+      ? event.pageY - window.scrollY
+      : (event.offsetY ?? event.layerY ?? 0),
+})
+
+const getObservedSize = entry => {
+  const borderBoxSize = Array.isArray(entry.borderBoxSize)
+    ? entry.borderBoxSize[0]
+    : entry.borderBoxSize
+
+  if (borderBoxSize)
+    return {
+      height: borderBoxSize.blockSize,
+      width: borderBoxSize.inlineSize,
+    }
+
+  return {
+    height: entry.contentRect.height,
+    width: entry.contentRect.width,
+  }
+}
+
 const Popover = ({ uiName }) => {
   const chart = useChart()
   const dropRef = useRef()
-  const [target, setTarget] = useState()
-  const targetRef = useRef()
-
-  const updatePositionRef = useRef()
+  const alignRef = useRef(rightBottomAlign)
+  const frameRef = useRef(null)
+  const pointerRef = useRef(null)
+  const positionRef = useRef(null)
+  const sizeRef = useRef(null)
+  const updatePositionRef = useRef(null)
+  const schedulePositionRef = useRef(null)
   const [open, setOpen] = useState(false)
   const [align, setAlign] = useState(rightBottomAlign)
 
-  targetRef.current = target
-  updatePositionRef.current = useMakeUpdatePosition(
-    target,
-    dropRef,
-    align,
-    undefined,
-    canHideTarget
-  )
+  alignRef.current = align
+  updatePositionRef.current = () => {
+    const drop = dropRef.current
+    const pointer = pointerRef.current
+    const size = sizeRef.current
+
+    if (!drop || !pointer || !size) return
+
+    const position = getPopoverPosition({
+      height: size.height,
+      pointerX: pointer.x,
+      pointerY: pointer.y,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+      width: size.width,
+    })
+
+    if (position.align !== alignRef.current) {
+      alignRef.current = position.align
+      setAlign(position.align)
+    }
+
+    const transform = `translate3d(${position.x}px, ${position.y}px, 0)`
+    if (transform === positionRef.current) return
+
+    positionRef.current = transform
+    drop.style.left = "0px"
+    drop.style.top = "0px"
+    drop.style.transform = transform
+  }
+  schedulePositionRef.current = () => {
+    if (frameRef.current !== null) return
+
+    frameRef.current = window.requestAnimationFrame(() => {
+      frameRef.current = null
+      updatePositionRef.current()
+    })
+  }
+
+  const cancelPosition = () => {
+    if (frameRef.current === null) return
+
+    window.cancelAnimationFrame(frameRef.current)
+    frameRef.current = null
+  }
 
   useEffect(() => {
-    return unregister(
+    const close = () => {
+      cancelPosition()
+      pointerRef.current = null
+      setOpen(false)
+    }
+    const off = unregister(
       chart.getUI(uiName).on("mousemove", event => {
         if (
           chart.sdk.getRoot().getAttribute("autofetchOnHovering") ||
@@ -50,71 +142,75 @@ const Popover = ({ uiName }) => {
         )
           return
 
-        const offsetX = event.offsetX || event.layerX
-        const offsetY = event.offsetY || event.layerY
-
-        if (!targetRef.current) {
-          setOpen(true)
-          return
-        }
-
-        targetRef.current.style.left = `${offsetX}px`
-        targetRef.current.style.top = `${offsetY}px`
-
+        pointerRef.current = getPointerPosition(event)
         setOpen(true)
-
-        if (!dropRef.current) return
-
-        updatePositionRef.current()
-
-        const { width, height } = dropRef.current.getBoundingClientRect()
-        const left = offsetX + width > window.innerWidth
-        const top = offsetY + height > window.innerHeight
-
-        setAlign(getAlign(left, top))
+        schedulePositionRef.current()
       }),
-      chart.getUI(uiName).on("mouseout", () => setOpen(false)),
-      chart.onAttributeChange("panning", panning => panning && setOpen(false)),
-      chart.onAttributeChange("highlighting", panning => panning && setOpen(false))
+      chart.getUI(uiName).on("mouseout", close),
+      chart.onAttributeChange("panning", panning => panning && close()),
+      chart.onAttributeChange("highlighting", highlighting => highlighting && close())
     )
-  }, [chart])
 
-  // After the DropContainer first mounts on open, position it (and recompute
-  // align based on overflow) before paint so the very first frame shows the
-  // popover at the cursor with the correct alignment.
+    return () => {
+      close()
+      off()
+    }
+  }, [chart, uiName])
+
   useLayoutEffect(() => {
-    if (!open || !targetRef.current || !dropRef.current) return
-    updatePositionRef.current?.()
-    const offsetX = parseFloat(targetRef.current.style.left) || 0
-    const offsetY = parseFloat(targetRef.current.style.top) || 0
-    const { width, height } = dropRef.current.getBoundingClientRect()
-    const left = offsetX + width > window.innerWidth
-    const top = offsetY + height > window.innerHeight
-    const next = getAlign(left, top)
-    if (next !== align) setAlign(next)
+    const drop = dropRef.current
+    if (!open || !drop) return
+
+    const rect = drop.getBoundingClientRect()
+    sizeRef.current = { height: rect.height, width: rect.width }
+    updatePositionRef.current()
+
+    let active = true
+    const resizeObserver = new ResizeObserver(entries => {
+      if (!active) return
+
+      const entry = entries[0]
+      if (!entry) return
+
+      const size = getObservedSize(entry)
+      if (size.height === sizeRef.current?.height && size.width === sizeRef.current?.width) return
+
+      sizeRef.current = size
+      schedulePositionRef.current()
+    })
+    const updateForViewport = () => schedulePositionRef.current()
+
+    resizeObserver.observe(drop, { box: "border-box" })
+    window.addEventListener("resize", updateForViewport)
+
+    return () => {
+      active = false
+      cancelPosition()
+      resizeObserver.disconnect()
+      window.removeEventListener("resize", updateForViewport)
+      positionRef.current = null
+      sizeRef.current = null
+    }
   }, [open])
 
   const el = useDropElement()
 
   return (
-    <Fragment>
-      <Flex ref={r => setTarget(r)} position="absolute" />
-      {open &&
-        ReactDOM.createPortal(
-          <DropContainer
-            data-toolbox={chart.getId()}
-            margin={[align.top ? 2 : -2, align.right ? -2 : 2]}
-            ref={dropRef}
-            column
-            data-testid="drop"
-            sx={{ pointerEvents: "none" }}
-            zIndex={101}
-          >
-            <Dimensions uiName={uiName} data-testid="chartPopover" />
-          </DropContainer>,
-          el
-        )}
-    </Fragment>
+    open &&
+    ReactDOM.createPortal(
+      <DropContainer
+        data-toolbox={chart.getId()}
+        margin={[align.top ? 2 : -2, align.right ? -2 : 2]}
+        ref={dropRef}
+        column
+        data-testid="drop"
+        sx={{ pointerEvents: "none" }}
+        zIndex={101}
+      >
+        <Dimensions uiName={uiName} data-testid="chartPopover" />
+      </DropContainer>,
+      el
+    )
   )
 }
 

--- a/src/components/line/popover/index.test.js
+++ b/src/components/line/popover/index.test.js
@@ -1,0 +1,88 @@
+import React from "react"
+import { act, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { makeTestChart, renderWithChart } from "@jest/testUtilities"
+import Popover, { getPopoverPosition } from "."
+
+const waitForFrame = () =>
+  new Promise(resolve => window.requestAnimationFrame(() => resolve()))
+
+describe("getPopoverPosition", () => {
+  it.each([
+    {
+      expected: { align: { left: "right", top: "bottom" }, x: 100, y: 80 },
+      pointerX: 100,
+      pointerY: 80,
+    },
+    {
+      expected: { align: { right: "left", top: "bottom" }, x: 350, y: 80 },
+      pointerX: 450,
+      pointerY: 80,
+    },
+    {
+      expected: { align: { bottom: "top", left: "right" }, x: 100, y: 270 },
+      pointerX: 100,
+      pointerY: 350,
+    },
+    {
+      expected: { align: { bottom: "top", right: "left" }, x: 350, y: 270 },
+      pointerX: 450,
+      pointerY: 350,
+    },
+  ])("positions the popover in the available quadrant", ({ expected, pointerX, pointerY }) => {
+    expect(
+      getPopoverPosition({
+        height: 80,
+        pointerX,
+        pointerY,
+        viewportHeight: 400,
+        viewportWidth: 500,
+        width: 100,
+      })
+    ).toEqual(expected)
+  })
+
+  it("keeps an oversized popover inside the viewport origin", () => {
+    expect(
+      getPopoverPosition({
+        height: 500,
+        pointerX: 50,
+        pointerY: 50,
+        viewportHeight: 400,
+        viewportWidth: 500,
+        width: 600,
+      })
+    ).toMatchObject({ x: 0, y: 0 })
+  })
+})
+
+describe("Popover", () => {
+  it("moves to the latest pointer position without remeasuring on every move", async () => {
+    const { chart } = makeTestChart()
+
+    renderWithChart(<Popover />, { chart })
+
+    await act(async () => {
+      chart.getUI().trigger("mousemove", { clientX: 100, clientY: 80 })
+      await waitForFrame()
+    })
+
+    const drop = screen.getByTestId("drop")
+    let geometryReads = 0
+
+    drop.getBoundingClientRect = () => {
+      geometryReads += 1
+      return { height: 120, width: 120 }
+    }
+
+    await act(async () => {
+      chart.getUI().trigger("mousemove", { clientX: 160, clientY: 120 })
+      chart.getUI().trigger("mousemove", { clientX: 220, clientY: 160 })
+      chart.getUI().trigger("mousemove", { clientX: 280, clientY: 200 })
+      await waitForFrame()
+    })
+
+    expect(drop.style.transform).toBe("translate3d(280px, 200px, 0)")
+    expect(geometryReads).toBe(0)
+  })
+})

--- a/src/components/provider/selectors.test.js
+++ b/src/components/provider/selectors.test.js
@@ -321,9 +321,10 @@ describe("Chart Provider Selectors", () => {
 
       const { result } = renderHookWithChart(() => useLatestValue("dim1"), { chart })
 
-      act(() => {
+      await act(async () => {
         chart.focus()
         sdk.trigger("highlightHover", chart, 1000, "dim1")
+        await new Promise(resolve => setTimeout(resolve, 20))
       })
 
       expect(result.current).toBe(50)

--- a/src/sdk/makeChart/makeDimensions.js
+++ b/src/sdk/makeChart/makeDimensions.js
@@ -13,6 +13,12 @@ import groupBy from "lodash/groupBy"
 import isEmpty from "lodash/isEmpty"
 import { getPointValue } from "./getPointValue"
 
+const dimensionNameCollator = new Intl.Collator(undefined, {
+  sensitivity: "accent",
+  ignorePunctuation: true,
+})
+const defaultDimensionNameCollator = new Intl.Collator()
+
 export default (chart, sdk) => {
   let prevDimensionIds = []
   let dimensionsById = {}
@@ -62,11 +68,8 @@ export default (chart, sdk) => {
       if (secondary) return secondary
 
       return namesDescending
-        ? b.name.localeCompare(a.name)
-        : a.name.localeCompare(b.name, undefined, {
-            sensitivity: "accent",
-            ignorePunctuation: true,
-          })
+        ? defaultDimensionNameCollator.compare(b.name, a.name)
+        : dimensionNameCollator.compare(a.name, b.name)
     })
 
     return dimensions.map(({ id }) => id)

--- a/src/sdk/makeChart/makeDimensions.test.js
+++ b/src/sdk/makeChart/makeDimensions.test.js
@@ -1027,4 +1027,17 @@ describe("makeDimensions heatmap bucket ordering", () => {
 
     expect(sorted).toEqual(["memory", "disk", "cpu"])
   })
+
+  it("preserves locale-aware name ordering when values are tied", async () => {
+    const ids = ["zulu", "alpha-value", "alpha_value", "Éclair", "eclair"]
+    const chart = await makeLineChart(ids, [ids.map(() => 1)])
+    const expected = [...ids].sort((left, right) =>
+      left.localeCompare(right, undefined, {
+        sensitivity: "accent",
+        ignorePunctuation: true,
+      })
+    )
+
+    expect(chart.onHoverSortDimensions(0, "valueDesc")).toEqual(expected)
+  })
 })

--- a/src/sdk/plugins/hover.js
+++ b/src/sdk/plugins/hover.js
@@ -1,14 +1,63 @@
+const requestFrame = callback => {
+  if (
+    typeof globalThis.requestAnimationFrame === "function" &&
+    typeof globalThis.cancelAnimationFrame === "function"
+  ) {
+    const id = globalThis.requestAnimationFrame(callback)
+    return () => globalThis.cancelAnimationFrame(id)
+  }
+
+  const id = globalThis.setTimeout(callback, 16)
+  return () => globalThis.clearTimeout(id)
+}
+
 export default sdk => {
-  return sdk
+  const pendingByGroup = new Map()
+  const getGroup = chart => chart.getAncestor({ syncHover: true }) || chart
+  const cancelPending = chart => {
+    const group = getGroup(chart)
+    pendingByGroup.get(group)?.cancel()
+    pendingByGroup.delete(group)
+  }
+  const clearHover = chart => {
+    cancelPending(chart)
+    chart
+      .getApplicableNodes({ syncHover: true })
+      .forEach(node => node.updateAttribute("hoverX", null))
+  }
+  const publishHover = ({ chart, dimensionX, dimensionY }) => {
+    chart.getApplicableNodes({ syncHover: true }).forEach(node => {
+      const hover = node.getAttribute("hoverX")
+      if (hover?.[0] === dimensionX && hover?.[1] === dimensionY) return
+
+      node.updateAttribute("hoverX", [dimensionX, dimensionY])
+    })
+  }
+  const scheduleHover = (chart, dimensionX, dimensionY) => {
+    const group = getGroup(chart)
+    const pending = pendingByGroup.get(group)
+
+    if (pending) {
+      pending.chart = chart
+      pending.dimensionX = dimensionX
+      pending.dimensionY = dimensionY
+      return
+    }
+
+    const next = { chart, dimensionX, dimensionY }
+    next.cancel = requestFrame(() => {
+      pendingByGroup.delete(group)
+      publishHover(next)
+    })
+    pendingByGroup.set(group, next)
+  }
+
+  const unregister = sdk
     .on("highlightHover", (chart, dimensionX, dimensionY) => {
-      chart
-        .getApplicableNodes({ syncHover: true })
-        .forEach(node => node.updateAttribute("hoverX", [dimensionX, dimensionY]))
+      scheduleHover(chart, dimensionX, dimensionY)
     })
     .on("highlightBlur", chart => {
-      chart
-        .getApplicableNodes({ syncHover: true })
-        .forEach(node => node.updateAttribute("hoverX", null))
+      clearHover(chart)
     })
     .on("hoverChart", chart => {
       chart.getApplicableNodes({ syncHover: true }).forEach(node => {
@@ -30,9 +79,16 @@ export default sdk => {
       sdk.trigger("play:hoverChart", chart)
     })
     .on("blurChart", chart => {
+      cancelPending(chart)
       chart.getApplicableNodes({ syncHover: true }).forEach(node => {
         node.updateAttributes({ hovering: false, hoverX: null, renderedAt: null })
       })
       sdk.trigger("play:blurChart", chart)
     })
+
+  return () => {
+    pendingByGroup.forEach(({ cancel }) => cancel())
+    pendingByGroup.clear()
+    unregister()
+  }
 }

--- a/src/sdk/plugins/hover.js
+++ b/src/sdk/plugins/hover.js
@@ -14,6 +14,10 @@ const requestFrame = callback => {
 export default sdk => {
   const pendingByGroup = new Map()
   const getGroup = chart => chart.getAncestor({ syncHover: true }) || chart
+  const cancelAllPending = () => {
+    pendingByGroup.forEach(({ cancel }) => cancel())
+    pendingByGroup.clear()
+  }
   const cancelPending = chart => {
     const group = getGroup(chart)
     pendingByGroup.get(group)?.cancel()
@@ -59,6 +63,9 @@ export default sdk => {
     .on("highlightBlur", chart => {
       clearHover(chart)
     })
+    .on("reconcilePlaybackState", options => {
+      if (options?.clearHover) cancelAllPending()
+    })
     .on("hoverChart", chart => {
       chart.getApplicableNodes({ syncHover: true }).forEach(node => {
         if (
@@ -87,8 +94,7 @@ export default sdk => {
     })
 
   return () => {
-    pendingByGroup.forEach(({ cancel }) => cancel())
-    pendingByGroup.clear()
+    cancelAllPending()
     unregister()
   }
 }

--- a/src/sdk/plugins/hover.test.js
+++ b/src/sdk/plugins/hover.test.js
@@ -1,0 +1,81 @@
+import makeSDK from "@/sdk"
+import hover from "./hover"
+
+const makeHoverSDK = () => {
+  const sdk = makeSDK({
+    ui: {},
+    plugins: { hover },
+  })
+  const first = sdk.makeChartCore()
+  const second = sdk.makeChartCore()
+
+  sdk.appendChild(first)
+  sdk.appendChild(second)
+
+  return { first, second, sdk }
+}
+
+describe("hover plugin", () => {
+  beforeEach(() => jest.useFakeTimers())
+
+  afterEach(() => jest.useRealTimers())
+
+  it("publishes only the latest synchronized hover within an animation frame", () => {
+    const { first, second, sdk } = makeHoverSDK()
+    const firstValues = []
+    const secondValues = []
+
+    first.onAttributeChange("hoverX", value => firstValues.push(value))
+    second.onAttributeChange("hoverX", value => secondValues.push(value))
+
+    sdk.trigger("highlightHover", first, 1000, "first")
+    sdk.trigger("highlightHover", first, 2000, "second")
+    sdk.trigger("highlightHover", first, 3000, "third")
+
+    expect(first.getAttribute("hoverX")).toBeNull()
+    expect(second.getAttribute("hoverX")).toBeNull()
+
+    jest.advanceTimersByTime(16)
+
+    expect(firstValues).toEqual([[3000, "third"]])
+    expect(secondValues).toEqual([[3000, "third"]])
+  })
+
+  it("does not republish an unchanged synchronized hover", () => {
+    const { first, second, sdk } = makeHoverSDK()
+    const values = []
+
+    second.onAttributeChange("hoverX", value => values.push(value))
+
+    sdk.trigger("highlightHover", first, 3000, "third")
+    jest.advanceTimersByTime(16)
+    sdk.trigger("highlightHover", first, 3000, "third")
+    jest.advanceTimersByTime(16)
+
+    expect(values).toEqual([[3000, "third"]])
+  })
+
+  it("cancels pending hover work when the pointer leaves", () => {
+    const { first, second, sdk } = makeHoverSDK()
+    const values = []
+
+    second.onAttributeChange("hoverX", value => values.push(value))
+
+    sdk.trigger("highlightHover", first, 3000, "third")
+    sdk.trigger("highlightBlur", first)
+    jest.advanceTimersByTime(16)
+
+    expect(second.getAttribute("hoverX")).toBeNull()
+    expect(values).toEqual([])
+  })
+
+  it("cancels pending hover work when the plugin is unregistered", () => {
+    const { first, second, sdk } = makeHoverSDK()
+
+    sdk.trigger("highlightHover", first, 3000, "third")
+    sdk.unregister("hover")
+    jest.advanceTimersByTime(16)
+
+    expect(second.getAttribute("hoverX")).toBeNull()
+  })
+})

--- a/src/sdk/plugins/play.test.js
+++ b/src/sdk/plugins/play.test.js
@@ -112,7 +112,7 @@ describe("play plugin", () => {
     window.removeEventListener("focus", reconcileHover)
   })
 
-  it("manual reconciliation clears hover blockers but preserves other reasons", () => {
+  it("manual reconciliation cancels pending hover work and preserves other reasons", () => {
     const playback = makePlaybackSDK()
     chart = playback.chart
     sdk = playback.sdk
@@ -131,6 +131,11 @@ describe("play plugin", () => {
     expect(root.getAttribute("hoverX")).toBeNull()
     expect(root.getPauseReasons()).toEqual([{ reasonId: "modal-1", reasonType: "interaction" }])
     expect(root.getAttribute("paused")).toBe(true)
+
+    jest.advanceTimersByTime(16)
+
+    expect(chart.getAttribute("hoverX")).toBeNull()
+    expect(root.getAttribute("hoverX")).toBeNull()
 
     root.removePauseReason("modal-1")
     expect(root.getAttribute("paused")).toBe(false)

--- a/src/sdk/plugins/play.test.js
+++ b/src/sdk/plugins/play.test.js
@@ -69,6 +69,7 @@ describe("play plugin", () => {
 
     chart.focus()
     sdk.trigger("highlightHover", chart, 1000, "dimension")
+    jest.advanceTimersByTime(16)
     expect(root.getAttribute("hovering")).toBe(true)
     expect(root.getAttribute("hoverX")).toEqual([1000, "dimension"])
 


### PR DESCRIPTION
## What changed

This PR removes four measured hot-path amplifiers without changing chart queries, payloads, refresh frequency, rendered values, or synchronized-hover behavior:

1. Reuse `Intl.Collator` instances during dimension sorting.
2. Coalesce synchronized hover broadcasts to one update per animation frame and skip identical positions.
3. Replace the value font-sizer's linear write/read loop with a bounded binary search.
4. Cache popover geometry and move it with a frame-coalesced transform.

Each optimization is isolated in its own commit.

## Why

A paused-dashboard hover profile showed 30 pointer movements consuming:

- 2,983 ms of main-thread task time
- 665 ms of JavaScript
- 271 ms of layout
- 103 ms of style recalculation
- 1,541 layouts and 1,642 style recalculations

A separate 20-movement audit recorded 3,399 DOM mutations, including 911 mutations on latest-value labels. The dominant problem was synchronized update fan-out plus repeated geometry and font-fit measurements.

The dimension-sort microbenchmark also showed that reusing the collator reduced locale-aware sorting of 6,000 tied dimensions from 19.665 ms to 0.504 ms per sort, and grouped ties from 46.909 ms to 1.358 ms per sort.

The font-fit path now needs at most seven layout probes instead of as many as forty. The popover tests verify that subsequent pointer movements perform no geometry reads.

## Compatibility

- Synchronized charts still share the timestamp while resolving their own rows.
- The latest pointer event wins within each frame.
- Pending hover work is cancelled on blur and teardown.
- Popover alignment and edge flipping are preserved.
- No artificial refresh backoff or global scheduling policy is introduced.

## Validation

- Full Jest suite: 156 suites passed; 1,534 tests passed and 2 skipped.
- Production build: 488 CommonJS and 488 ES module files compiled.
- ESLint passes for every changed file.
- Isolated Storybook check: synchronized charts rendered, hover followed the latest pointer position, viewport-edge flipping worked, and no console errors occurred.
